### PR TITLE
Feature/battle page

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -986,8 +986,11 @@ def api_battle_vote():
     if not winner_id or not loser_id:
         return jsonify({'error': 'Missing IDs'}), 400
 
-    winner = Song.query.get(winner_id)
-    loser = Song.query.get(loser_id)
+    if winner_id == loser_id:
+        return jsonify({'error': 'winner_id and loser_id must be different'}), 400
+
+    winner = db.session.get(Song, winner_id)
+    loser = db.session.get(Song, loser_id)
 
     if not winner or not loser:
         return jsonify({'error': 'Song not found'}), 404

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request, current_app, make_response
+from datetime import datetime, timezone
 from flask_login import login_required, current_user
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
@@ -938,6 +939,95 @@ def get_leaderboard_songs():
             },
         }
     )
+
+
+@bp.route('/battle', methods=['GET'])
+@bp_v1.route('/battle', methods=['GET'])
+def api_get_battle():
+    """Return two random songs for a face-off as JSON."""
+    current_album = Album.query.filter_by(is_current=True).first()
+    max_queue_order = current_album.queue_order if current_album else 0
+
+    songs = Song.query.join(Album).filter(
+        Album.queue_order > 0,
+        Album.queue_order <= max_queue_order,
+        Song.ignored == False
+    ).order_by(func.random()).limit(2).all()
+
+    if len(songs) < 2:
+        return jsonify({'error': 'Not enough songs to battle!'}), 404
+
+    def _song_payload(song):
+        return {
+            'id': song.id,
+            'title': song.title,
+            'spotify_url': song.spotify_url,
+            'apple_url': song.apple_url,
+            'youtube_url': song.youtube_url,
+            'album': {
+                'id': song.album.id if song.album else None,
+                'title': song.album.title if song.album else None,
+                'artist': song.album.artist if song.album else None,
+                'cover_url': song.album.cover_url if song.album else None,
+            },
+        }
+
+    return jsonify({'song1': _song_payload(songs[0]), 'song2': _song_payload(songs[1])})
+
+
+@bp.route('/battle/vote', methods=['POST'])
+@bp_v1.route('/battle/vote', methods=['POST'])
+def api_battle_vote():
+    """Handle a battle vote via JSON and return rating changes."""
+    data = request.get_json(silent=True) or {}
+    winner_id = data.get('winner_id')
+    loser_id = data.get('loser_id')
+
+    if not winner_id or not loser_id:
+        return jsonify({'error': 'Missing IDs'}), 400
+
+    winner = Song.query.get(winner_id)
+    loser = Song.query.get(loser_id)
+
+    if not winner or not loser:
+        return jsonify({'error': 'Song not found'}), 404
+
+    user_id = current_user.id if current_user.is_authenticated else None
+    battle_vote = BattleVote(
+        user_id=user_id,
+        winner_id=winner_id,
+        loser_id=loser_id,
+        timestamp=datetime.now(timezone.utc)
+    )
+    db.session.add(battle_vote)
+
+    # Elo calculation (K = 32)
+    K = 32
+    Rw = winner.elo_rating
+    Rl = loser.elo_rating
+    Ew = 1 / (1 + 10 ** ((Rl - Rw) / 400))
+    El = 1 / (1 + 10 ** ((Rw - Rl) / 400))
+
+    winner.elo_rating = Rw + K * (1 - Ew)
+    loser.elo_rating = Rl + K * (0 - El)
+
+    winner.match_count += 1
+    loser.match_count += 1
+
+    db.session.commit()
+
+    return jsonify({
+        'winner': {
+            'id': winner.id,
+            'new_rating': round(winner.elo_rating, 1),
+            'gain': round(winner.elo_rating - Rw, 1),
+        },
+        'loser': {
+            'id': loser.id,
+            'new_rating': round(loser.elo_rating, 1),
+            'loss': round(loser.elo_rating - Rl, 1),
+        },
+    })
 
 
 # -------- Retro voting endpoints --------

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Header from "./components/layout/Header";
 import RetroVoteCard from "./components/retro/RetroVoteCard";
 import VoteCard from "./components/vote/VoteCard";
 import FaceoffLeaderboardPage from "./pages/FaceoffLeaderboardPage";
+import BattlePage from "./pages/BattlePage";
 import ResultsPage from "./pages/ResultsPage";
 import RetroHubPage from "./pages/RetroHubPage";
 import RetroVotePage from "./pages/RetroVotePage";
@@ -42,6 +43,10 @@ function parseHashRoute(hash) {
 
   if (pathOnly === "/faceoff-leaderboard") {
     return { page: "/faceoff-leaderboard", albumId: null };
+  }
+
+  if (pathOnly === "/battle") {
+    return { page: "/battle", albumId: null };
   }
 
   if (pathOnly === "/top-albums") {
@@ -89,7 +94,7 @@ function App() {
   } = useVotingFlow();
   const retro = useRetroVotingFlow(sessionState === "authenticated");
   const { setSelectedAlbumId } = retro;
-  const isPublicDataPage = ["/results", "/top-artists", "/faceoff-leaderboard", "/top-albums", "/top-songs"].includes(route.page);
+  const isPublicDataPage = ["/results", "/top-artists", "/faceoff-leaderboard", "/top-albums", "/top-songs", "/battle"].includes(route.page);
 
   useEffect(() => {
     function onHashChange() {
@@ -165,6 +170,10 @@ function App() {
 
         {route.page === "/faceoff-leaderboard" && sessionState !== "loading" && sessionState !== "error" ? (
           <FaceoffLeaderboardPage />
+        ) : null}
+
+        {route.page === "/battle" && sessionState !== "loading" && sessionState !== "error" ? (
+          <BattlePage sessionState={sessionState} theme={theme} />
         ) : null}
 
         {route.page === "/top-albums" && sessionState !== "loading" && sessionState !== "error" ? (

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -168,8 +168,22 @@ export function oauthLoginHref() {
   return buildUrl("/oauth/login");
 }
 
-export function getBattle() {
-  return request("/api/v1/battle");
+let battleInFlightRequest = null;
+
+export function getBattle(options = {}) {
+  const { force = false } = options;
+
+  // Deduplicate concurrent battle fetches so initial render doesn't swap pairs
+  // when React dev mode invokes effects more than once.
+  if (!force && battleInFlightRequest) {
+    return battleInFlightRequest;
+  }
+
+  battleInFlightRequest = request("/api/v1/battle").finally(() => {
+    battleInFlightRequest = null;
+  });
+
+  return battleInFlightRequest;
 }
 
 export function submitBattleVote(payload) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -168,6 +168,17 @@ export function oauthLoginHref() {
   return buildUrl("/oauth/login");
 }
 
+export function getBattle() {
+  return request("/api/v1/battle");
+}
+
+export function submitBattleVote(payload) {
+  return request(`/api/v1/battle/vote`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
 export function legacyLoginHref() {
   return buildUrl("/legacy/login");
 }

--- a/frontend/src/components/battle/BattleCard.jsx
+++ b/frontend/src/components/battle/BattleCard.jsx
@@ -22,6 +22,10 @@ export default function BattleCard({ song, onVote, disabled, id, theme }) {
     }
   };
 
+  const stopVoteBubble = (e) => {
+    e.stopPropagation();
+  };
+
   return (
     <div
       className="battle-card"
@@ -43,7 +47,7 @@ export default function BattleCard({ song, onVote, disabled, id, theme }) {
       <div className="battle-info">
         <h3>{song.title}</h3>
         <p>{song.album?.artist}</p>
-        <div className="song-links">
+        <div className="song-links" onClick={stopVoteBubble} onKeyDown={stopVoteBubble}>
           <StreamingLinks
             spotifyUrl={song.spotify_url}
             appleUrl={song.apple_url}
@@ -53,7 +57,7 @@ export default function BattleCard({ song, onVote, disabled, id, theme }) {
         </div>
 
         {song.spotify_url ? (
-          <div className="spotify-embed-container">
+          <div className="spotify-embed-container" onClick={stopVoteBubble} onKeyDown={stopVoteBubble}>
             <div className={`spotify-embed-wrapper ${iframeLoaded ? "loaded" : "loading"}`}>
               <div className="spotify-skeleton" role="img" aria-label="Loading player" aria-hidden={iframeLoaded}>
                 <div className="sk-thumb" />

--- a/frontend/src/components/battle/BattleCard.jsx
+++ b/frontend/src/components/battle/BattleCard.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from "react";
+import StreamingLinks from "../common/StreamingLinks";
+import { getSpotifyTrackId } from "../../utils/spotify";
+
+export default function BattleCard({ song, onVote, disabled, id, theme }) {
+  if (!song) return null;
+
+  const [iframeLoaded, setIframeLoaded] = useState(false);
+
+  const handleClick = () => {
+    if (disabled) return;
+    onVote && onVote(song.id);
+  };
+
+  const onKeyDown = (e) => {
+    if (disabled) return;
+    if (e.key === "Enter") {
+      onVote && onVote(song.id);
+    } else if (e.key === " " || e.code === "Space") {
+      e.preventDefault();
+      onVote && onVote(song.id);
+    }
+  };
+
+  return (
+    <div
+      className="battle-card"
+      id={id}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      onClick={handleClick}
+      onKeyDown={onKeyDown}
+      aria-disabled={disabled}
+      aria-label={`Vote for ${song.title} by ${song.album?.artist || "unknown"}`}
+    >
+      <div className="battle-cover">
+        {song.album?.cover_url ? <img src={song.album.cover_url} alt={song.album.title} /> : null}
+        <div className="battle-overlay">
+          <span className="vote-text">VOTE</span>
+        </div>
+      </div>
+
+      <div className="battle-info">
+        <h3>{song.title}</h3>
+        <p>{song.album?.artist}</p>
+        <div className="song-links">
+          <StreamingLinks
+            spotifyUrl={song.spotify_url}
+            appleUrl={song.apple_url}
+            youtubeUrl={song.youtube_url}
+            mode="icons"
+          />
+        </div>
+
+        {song.spotify_url ? (
+          <div className="spotify-embed-container">
+            <div className={`spotify-embed-wrapper ${iframeLoaded ? "loaded" : "loading"}`}>
+              <div className="spotify-skeleton" role="img" aria-label="Loading player" aria-hidden={iframeLoaded}>
+                <div className="sk-thumb" />
+                <div className="sk-body">
+                  <div className="sk-line sk-short" />
+                  <div className="sk-line sk-long" />
+                  <div className="sk-progress" />
+                </div>
+              </div>
+              {/* Use passed theme when available, fallback to document attribute */}
+              {(() => {
+                const docTheme = typeof document !== "undefined" ? document.documentElement.getAttribute("data-theme") : "dark";
+                const useTheme = theme || docTheme || "dark";
+                // Spotify embed expects theme=1 for light, 0 for dark; map accordingly
+                const spotifyTheme = useTheme === "light" ? "1" : "0";
+                const trackId = getSpotifyTrackId(song.spotify_url);
+                const src = `https://open.spotify.com/embed/track/${trackId}?utm_source=generator&theme=${spotifyTheme}`;
+                return (
+                  <iframe
+                    src={src}
+                    width="100%"
+                    height="80"
+                    frameBorder="0"
+                    onLoad={() => setIframeLoaded(true)}
+                    allowFullScreen=""
+                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                    loading="lazy"
+                    style={{ display: "block", borderRadius: "12px", border: "none", background: "transparent", opacity: iframeLoaded ? 1 : 0, transition: "opacity .18s ease" }}
+                  />
+                );
+              })()}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/battle/BattleSkeleton.css
+++ b/frontend/src/components/battle/BattleSkeleton.css
@@ -1,0 +1,74 @@
+.battle-skeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 36px;
+  width: 100%;
+  flex-wrap: wrap;
+  padding: 12px 0;
+}
+
+.battle-skel-card {
+  width: 360px;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.battle-skel-cover {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+}
+
+.battle-skel-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.battle-skel-title { height: 20px; width: 78%; border-radius: 8px; }
+.battle-skel-artist { height: 14px; width: 42%; border-radius: 8px; }
+
+.battle-skel-links { display:flex; gap:8px; }
+.battle-skel-chip { width:44px; height:28px; border-radius:999px; }
+
+.battle-skel-embed { width:100%; height:80px; border-radius:12px; border:1px solid var(--border-color); background: var(--card-bg); overflow: hidden; }
+
+.vs-skel-badge {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--border-color);
+  font-weight: 800;
+}
+
+@media (max-width: 700px) {
+  .battle-skeleton { gap: 20px; }
+  .battle-skel-card { width: 84vw; max-width: 420px; }
+  .vs-skel-badge { display: none; }
+}
+
+/* Shimmer animation for skeleton elements (self-contained) */
+.battle-skel-shimmer {
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--bg) 82%, var(--card-bg)),
+    color-mix(in oklab, var(--card-bg) 72%, white 10%),
+    color-mix(in oklab, var(--bg) 82%, var(--card-bg))
+  );
+  background-size: 220% 100%;
+  animation: battle-shimmer 1.2s linear infinite;
+}
+
+@keyframes battle-shimmer {
+  from { background-position: 220% 0; }
+  to { background-position: -220% 0; }
+}
+

--- a/frontend/src/components/battle/BattleSkeleton.jsx
+++ b/frontend/src/components/battle/BattleSkeleton.jsx
@@ -1,0 +1,37 @@
+import "./BattleSkeleton.css";
+
+export default function BattleSkeleton() {
+  return (
+    <div className="battle-skeleton" role="status" aria-live="polite" aria-label="Loading face-off pair">
+      <div className="battle-skel-card">
+        <div className="battle-skel-cover battle-skel-shimmer" />
+        <div className="battle-skel-meta">
+          <div className="battle-skel-title battle-skel-shimmer" />
+          <div className="battle-skel-artist battle-skel-shimmer" />
+          <div className="battle-skel-links">
+            <div className="battle-skel-chip battle-skel-shimmer" />
+            <div className="battle-skel-chip battle-skel-shimmer" />
+            <div className="battle-skel-chip battle-skel-shimmer" />
+          </div>
+          <div className="battle-skel-embed battle-skel-shimmer" />
+        </div>
+      </div>
+
+      <div className="vs-skel-badge battle-skel-shimmer" aria-hidden="true">VS</div>
+
+      <div className="battle-skel-card">
+        <div className="battle-skel-cover battle-skel-shimmer" />
+        <div className="battle-skel-meta">
+          <div className="battle-skel-title battle-skel-shimmer" />
+          <div className="battle-skel-artist battle-skel-shimmer" />
+          <div className="battle-skel-links">
+            <div className="battle-skel-chip battle-skel-shimmer" />
+            <div className="battle-skel-chip battle-skel-shimmer" />
+            <div className="battle-skel-chip battle-skel-shimmer" />
+          </div>
+          <div className="battle-skel-embed battle-skel-shimmer" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -114,7 +114,7 @@ export default function Header({
             {sessionState === "authenticated" && (
               <>
                 <a href="#/vote" className={route === "/vote" ? "active" : ""} onClick={closeMobileOverlays}>Vote</a>
-                <a href={legacyPageHref("/battle")} onClick={closeMobileOverlays}>Face-Off</a>
+                <a href="#/battle" className={route === "/battle" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off</a>
                 <a href="#/retro-hub" className={route === "/retro-hub" || route === "/retro-vote" ? "active" : ""} onClick={closeMobileOverlays}>Retro Hub</a>
               </>
             )}

--- a/frontend/src/pages/BattlePage.css
+++ b/frontend/src/pages/BattlePage.css
@@ -1,0 +1,259 @@
+.battle-card-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.battle-arena {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 40px;
+  position: relative;
+}
+
+@media (max-width: 700px) {
+  .battle-arena {
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .vs-badge {
+    position: relative;
+    margin: 10px 0;
+  }
+}
+
+.battle-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 16px;
+  width: 360px;
+  max-width: 42vw;
+  min-width: 260px;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.12s, box-shadow 0.12s;
+  position: relative;
+}
+
+.battle-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 20px rgba(0,0,0,0.3);
+  border-color: var(--accent);
+}
+
+/* Keyboard focus ring for accessibility */
+.battle-card:focus-visible {
+  outline: 3px solid color-mix(in oklab, var(--accent) 70%, var(--bg));
+  outline-offset: 4px;
+}
+
+/* Visual state when voting is temporarily disabled */
+.battle-card[aria-disabled="true"] {
+  opacity: 0.7;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.battle-cover {
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.battle-cover img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.battle-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.battle-card:hover .battle-overlay {
+  opacity: 1;
+}
+
+.vote-text {
+  background: var(--accent);
+  color: white;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-weight: bold;
+}
+
+.battle-info h3 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  line-height: 1.3;
+}
+
+.battle-info p {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.song-links { display:flex; justify-content:center; gap:12px; margin-bottom:12px; }
+.song-links a { color: var(--muted); font-size:1.2rem; }
+.song-links a:hover { color: var(--accent); }
+
+.spotify-embed-container { margin-top: 10px; display:flex; justify-content:center; }
+
+/* Wrapper matches spotify embed theme and clips overflow */
+.spotify-embed-wrapper { position: relative; border-radius: 12px; overflow: hidden; background: var(--card-bg); height: 80px; }
+
+
+/* Use the V1 approach: give the iframe the rounded corners and no borders.
+   Keep a simple wrapper for layout only and avoid scaling/overlay hacks. */
+.spotify-embed-wrapper iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 64px;
+  min-width: 160px;
+  max-width: 420px;
+  border: none;
+  border-radius: 12px;
+}
+
+@media (max-width: 520px) {
+  .spotify-embed-wrapper iframe { min-width: 160px; height: 80px; }
+}
+
+/* Spotify embed skeleton placeholder while iframe loads */
+.spotify-embed-wrapper.loading .spotify-skeleton { display: flex; }
+.spotify-embed-wrapper.loaded .spotify-skeleton { display: none; }
+.spotify-skeleton {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 12px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}
+.spotify-skeleton .sk-thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, color-mix(in oklab, var(--bg) 86%, var(--card-bg)), color-mix(in oklab, var(--card-bg) 72%, white 10%));
+  background-size: 200% 100%;
+  animation: spotify-skel-shimmer 1.2s linear infinite;
+}
+.spotify-skeleton .sk-body { flex: 1; display: flex; flex-direction: column; gap: 8px; }
+.spotify-skeleton .sk-line { height: 12px; border-radius: 6px; background: linear-gradient(90deg, color-mix(in oklab, var(--bg) 86%, var(--card-bg)), color-mix(in oklab, var(--card-bg) 72%, white 10%)); background-size: 200% 100%; animation: spotify-skel-shimmer 1.2s linear infinite; }
+.spotify-skeleton .sk-line.sk-short { width: 40%; }
+.spotify-skeleton .sk-line.sk-long { width: 80%; }
+.spotify-skeleton .sk-progress { height: 6px; border-radius: 999px; background: var(--input-bg); width: 100%; margin-top: 6px; }
+
+@keyframes spotify-skel-shimmer { 0% { background-position: 200% 0 } to { background-position: -200% 0 } }
+
+/* Fade iframe in only after it has fully loaded to avoid a white flash */
+.spotify-embed-wrapper.loading iframe {
+  opacity: 0;
+  visibility: hidden;
+}
+.spotify-embed-wrapper.loaded iframe {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 180ms ease;
+}
+
+.vs-badge {
+  background: #000;
+  color: white;
+  font-weight: 800;
+  padding: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  font-style: italic;
+}
+
+.result-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.8);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:1000;
+  backdrop-filter: blur(5px);
+}
+
+.result-modal {
+  background: var(--card-bg);
+  padding: 40px;
+  border-radius: 16px;
+  text-align: center;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+  border: 1px solid var(--border-color);
+}
+
+.rating-change { font-size: 2rem; font-weight: 800; margin: 20px 0; }
+.diff-positive { color: var(--accent); }
+.diff-negative { color: #ff5555; }
+
+.login-suggestion { text-align:center; margin-top:32px; }
+.skip-container { text-align:center; margin-top:24px; display:flex; flex-direction:column; gap:12px; align-items:center; }
+
+@media (min-width: 700px) {
+  .skip-container { flex-direction:row; gap:16px; justify-content:center; }
+  .skip-container .btn { min-width: 160px; }
+}
+
+/* Enhanced bottom button styling for Battle page */
+.skip-container .btn {
+  border-radius: 12px;
+  padding: 0.6rem 1rem;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.32);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.skip-container .btn.btn-secondary {
+  background: color-mix(in oklab, var(--bg) 88%, var(--card-bg));
+  border-color: color-mix(in oklab, var(--accent) 12%, var(--border-color));
+}
+
+.skip-container .btn.btn-secondary:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 30px rgba(0,0,0,0.42);
+  border-color: var(--accent);
+}
+
+.skip-container .muted-link {
+  color: var(--muted);
+  text-decoration: none;
+  border-bottom: 1px dotted color-mix(in oklab, var(--muted) 48%, transparent);
+  padding-bottom: 2px;
+  transition: color 160ms ease, border-bottom-color 160ms ease;
+}
+
+.skip-container .muted-link:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}

--- a/frontend/src/pages/BattlePage.css
+++ b/frontend/src/pages/BattlePage.css
@@ -219,6 +219,12 @@
 .diff-negative { color: #ff5555; }
 
 .login-suggestion { text-align:center; margin-top:32px; }
+.battle-inline-error {
+  margin: 14px 0 0;
+  text-align: center;
+  color: var(--error-color);
+  font-weight: 600;
+}
 .skip-container { text-align:center; margin-top:24px; display:flex; flex-direction:column; gap:12px; align-items:center; }
 
 @media (min-width: 700px) {

--- a/frontend/src/pages/BattlePage.jsx
+++ b/frontend/src/pages/BattlePage.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { getBattle, submitBattleVote } from "../api";
+import StatusCard from "../components/common/StatusCard";
+import BattleCard from "../components/battle/BattleCard";
+import BattleSkeleton from "../components/battle/BattleSkeleton";
+import "./BattlePage.css";
+
+export default function BattlePage({ sessionState, theme }) {
+  const [state, setState] = useState("loading");
+  const [song1, setSong1] = useState(null);
+  const [song2, setSong2] = useState(null);
+  const [error, setError] = useState(null);
+  const [result, setResult] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    loadPair();
+  }, []);
+
+  // Add preconnect hints to Spotify domains to reduce embed load time (reduces white flash)
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const addPreconnect = (href) => {
+      if (document.querySelector(`link[rel=\"preconnect\"][href=\"${href}\"]`)) return;
+      const l = document.createElement("link");
+      l.rel = "preconnect";
+      l.href = href;
+      l.crossOrigin = "anonymous";
+      document.head.appendChild(l);
+    };
+
+    addPreconnect("https://open.spotify.com");
+    addPreconnect("https://i.scdn.co");
+  }, []);
+
+  async function loadPair() {
+    setState("loading");
+    setError(null);
+    try {
+      const payload = await getBattle();
+      setSong1(payload.song1);
+      setSong2(payload.song2);
+      setState("ready");
+    } catch (err) {
+      setError(err.message || String(err));
+      setState("error");
+    }
+  }
+
+  async function handleVote(winnerId, loserId) {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const data = await submitBattleVote({ winner_id: winnerId, loser_id: loserId });
+      setResult(data);
+    } catch (err) {
+      setError(err.message || String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function closeResult() {
+    setResult(null);
+    loadPair();
+  }
+
+  if (state === "error") return <StatusCard title="Could not load battle" message={error} variant="error" />;
+
+  return (
+    <section className="battle-card-page">
+      <div className="battle-container">
+        <div className="battle-arena">
+          {state === "loading" ? (
+            <BattleSkeleton />
+          ) : (
+            <>
+              {song1 ? (
+                <BattleCard
+                  song={song1}
+                  id="card-1"
+                  disabled={submitting}
+                  onVote={(id) => handleVote(id, song2?.id)}
+                  theme={theme}
+                />
+              ) : null}
+
+              <div className="vs-badge">VS</div>
+
+              {song2 ? (
+                <BattleCard
+                  song={song2}
+                  id="card-2"
+                  disabled={submitting}
+                  onVote={(id) => handleVote(id, song1?.id)}
+                  theme={theme}
+                />
+              ) : null}
+            </>
+          )}
+        </div>
+
+        {sessionState !== "authenticated" ? (
+          <div className="login-suggestion fade-in">
+            <p style={{ margin: 0, marginBottom: 8, fontWeight: "bold" }}>Want to track your voting history?</p>
+            <a className="btn btn-primary" href={legacyPageHref("/login")}>Log In Now</a>
+          </div>
+        ) : null}
+
+        <div className="skip-container">
+          <button className="btn btn-secondary" type="button" onClick={loadPair}>Skip this match</button>
+          <a className="muted-link" href="#/faceoff-leaderboard">View Face-Off Leaderboard</a>
+        </div>
+
+        {result ? (
+          <div id="result-overlay" className="result-overlay">
+            <div className="result-modal pop-in" role="dialog" aria-modal="true" aria-labelledby="result-heading">
+              <h2 id="result-heading">Winner!</h2>
+              <div className="result-content" aria-live="polite">
+                <div id="winner-display">
+                  <p style={{ fontWeight: 800, fontSize: "1.1rem" }}>
+                    New rating: {result.winner?.new_rating}
+                  </p>
+                </div>
+                <div className="rating-change">
+
+                  <span id="rating-diff" className="diff-positive">+{result.winner?.gain}</span>
+                </div>
+              </div>
+              <button className="btn btn-primary" onClick={closeResult}>Next Battle</button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/BattlePage.jsx
+++ b/frontend/src/pages/BattlePage.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { getBattle, submitBattleVote } from "../api";
+import { useEffect, useRef, useState } from "react";
+import { getBattle, legacyPageHref, submitBattleVote } from "../api";
 import StatusCard from "../components/common/StatusCard";
 import BattleCard from "../components/battle/BattleCard";
 import BattleSkeleton from "../components/battle/BattleSkeleton";
@@ -12,6 +12,7 @@ export default function BattlePage({ sessionState, theme }) {
   const [error, setError] = useState(null);
   const [result, setResult] = useState(null);
   const [submitting, setSubmitting] = useState(false);
+  const requestSeq = useRef(0);
 
   useEffect(() => {
     loadPair();
@@ -33,15 +34,25 @@ export default function BattlePage({ sessionState, theme }) {
     addPreconnect("https://i.scdn.co");
   }, []);
 
-  async function loadPair() {
+  async function loadPair(options = {}) {
+    const { force = false } = options;
+    const seq = requestSeq.current + 1;
+    requestSeq.current = seq;
+
     setState("loading");
     setError(null);
     try {
-      const payload = await getBattle();
+      const payload = await getBattle({ force });
+      if (seq !== requestSeq.current) {
+        return;
+      }
       setSong1(payload.song1);
       setSong2(payload.song2);
       setState("ready");
     } catch (err) {
+      if (seq !== requestSeq.current) {
+        return;
+      }
       setError(err.message || String(err));
       setState("error");
     }
@@ -62,7 +73,7 @@ export default function BattlePage({ sessionState, theme }) {
 
   function closeResult() {
     setResult(null);
-    loadPair();
+    loadPair({ force: true });
   }
 
   if (state === "error") return <StatusCard title="Could not load battle" message={error} variant="error" />;
@@ -108,7 +119,7 @@ export default function BattlePage({ sessionState, theme }) {
         ) : null}
 
         <div className="skip-container">
-          <button className="btn btn-secondary" type="button" onClick={loadPair}>Skip this match</button>
+          <button className="btn btn-secondary" type="button" onClick={() => loadPair({ force: true })}>Skip this match</button>
           <a className="muted-link" href="#/faceoff-leaderboard">View Face-Off Leaderboard</a>
         </div>
 

--- a/frontend/src/pages/BattlePage.jsx
+++ b/frontend/src/pages/BattlePage.jsx
@@ -13,6 +13,7 @@ export default function BattlePage({ sessionState, theme }) {
   const [result, setResult] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const requestSeq = useRef(0);
+  const canVote = state === "ready" && !!song1 && !!song2 && !submitting;
 
   useEffect(() => {
     loadPair();
@@ -60,6 +61,16 @@ export default function BattlePage({ sessionState, theme }) {
 
   async function handleVote(winnerId, loserId) {
     if (submitting) return;
+    if (!winnerId || !loserId) {
+      setError("Battle pair is still loading. Please wait a moment and try again.");
+      return;
+    }
+    if (winnerId === loserId) {
+      setError("Invalid vote: winner and loser cannot be the same song.");
+      return;
+    }
+
+    setError(null);
     setSubmitting(true);
     try {
       const data = await submitBattleVote({ winner_id: winnerId, loser_id: loserId });
@@ -90,7 +101,7 @@ export default function BattlePage({ sessionState, theme }) {
                 <BattleCard
                   song={song1}
                   id="card-1"
-                  disabled={submitting}
+                  disabled={!canVote}
                   onVote={(id) => handleVote(id, song2?.id)}
                   theme={theme}
                 />
@@ -102,7 +113,7 @@ export default function BattlePage({ sessionState, theme }) {
                 <BattleCard
                   song={song2}
                   id="card-2"
-                  disabled={submitting}
+                  disabled={!canVote}
                   onVote={(id) => handleVote(id, song1?.id)}
                   theme={theme}
                 />
@@ -110,6 +121,10 @@ export default function BattlePage({ sessionState, theme }) {
             </>
           )}
         </div>
+
+        {state === "ready" && error ? (
+          <p className="battle-inline-error" role="alert">{error}</p>
+        ) : null}
 
         {sessionState !== "authenticated" ? (
           <div className="login-suggestion fade-in">

--- a/frontend/src/pages/FaceoffLeaderboardPage.jsx
+++ b/frontend/src/pages/FaceoffLeaderboardPage.jsx
@@ -157,7 +157,7 @@ export default function FaceoffLeaderboardPage() {
           <h1>Face-Off Leaderboard</h1>
           <p className="subtitle">Elo-based fan favorites ranked by battle outcomes.</p>
         </div>
-        <a className="btn btn-primary" href={legacyPageHref("/battle")}>Play Face-Off</a>
+        <a className="btn btn-primary" href="#/battle">Play Face-Off</a>
       </section>
 
       <LeaderboardToolbar

--- a/tests/test_api_v1_contracts.py
+++ b/tests/test_api_v1_contracts.py
@@ -380,6 +380,106 @@ def test_leaderboard_battle_contract_matches_v1_and_user_counts():
         db.drop_all()
 
 
+def test_battle_pair_contract_returns_expected_shape_and_distinct_songs():
+    app = _build_app()
+    with app.app_context():
+        db.create_all()
+
+    _seed_authenticated_user_and_album(app)
+    client = app.test_client()
+
+    response = client.get("/api/v1/battle")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert set(payload.keys()) == {"song1", "song2"}
+
+    for key in ("song1", "song2"):
+        song = payload[key]
+        assert set(song.keys()) == {"id", "title", "spotify_url", "apple_url", "youtube_url", "album"}
+        assert set(song["album"].keys()) == {"id", "title", "artist", "cover_url"}
+
+    assert payload["song1"]["id"] != payload["song2"]["id"]
+
+    with app.app_context():
+        db.drop_all()
+
+
+def test_battle_vote_happy_path_updates_elo_and_returns_payload():
+    app = _build_app()
+    with app.app_context():
+        db.create_all()
+
+    user_id = _seed_authenticated_user_and_album(app)
+    client = app.test_client()
+    _login(client, user_id)
+
+    with app.app_context():
+        songs = Song.query.order_by(Song.track_number.asc()).all()
+        winner_song = songs[0]
+        loser_song = songs[1]
+        winner_id = winner_song.id
+        loser_id = loser_song.id
+        winner_before = float(winner_song.elo_rating)
+        loser_before = float(loser_song.elo_rating)
+        winner_match_before = int(winner_song.match_count or 0)
+        loser_match_before = int(loser_song.match_count or 0)
+
+    response = client.post("/api/v1/battle/vote", json={"winner_id": winner_id, "loser_id": loser_id})
+    assert response.status_code == 200
+
+    payload = response.get_json()
+    assert set(payload.keys()) == {"winner", "loser"}
+    assert set(payload["winner"].keys()) == {"id", "new_rating", "gain"}
+    assert set(payload["loser"].keys()) == {"id", "new_rating", "loss"}
+    assert payload["winner"]["id"] == winner_id
+    assert payload["loser"]["id"] == loser_id
+
+    with app.app_context():
+        winner_after = db.session.get(Song, winner_id)
+        loser_after = db.session.get(Song, loser_id)
+        vote_rows = BattleVote.query.all()
+
+        assert len(vote_rows) == 1
+        assert winner_after.elo_rating > winner_before
+        assert loser_after.elo_rating < loser_before
+        assert winner_after.match_count == winner_match_before + 1
+        assert loser_after.match_count == loser_match_before + 1
+
+    with app.app_context():
+        db.drop_all()
+
+
+def test_battle_vote_rejects_same_winner_and_loser_ids():
+    app = _build_app()
+    with app.app_context():
+        db.create_all()
+
+    user_id = _seed_authenticated_user_and_album(app)
+    client = app.test_client()
+    _login(client, user_id)
+
+    with app.app_context():
+        song = Song.query.order_by(Song.track_number.asc()).first()
+        song_id = song.id
+        elo_before = float(song.elo_rating)
+        match_before = int(song.match_count or 0)
+
+    response = client.post("/api/v1/battle/vote", json={"winner_id": song_id, "loser_id": song_id})
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "winner_id and loser_id must be different"}
+
+    with app.app_context():
+        song_after = db.session.get(Song, song_id)
+        vote_count = BattleVote.query.count()
+        assert song_after.elo_rating == elo_before
+        assert song_after.match_count == match_before
+        assert vote_count == 0
+
+    with app.app_context():
+        db.drop_all()
+
+
 def test_leaderboard_artist_bio_contract_matches_v1_with_cache():
     app = _build_app()
     with app.app_context():


### PR DESCRIPTION
## Summary

Implemented the V2 battle page (`#/battle`) to match V1 behavior, including:

- New V2 battle UI with reusable components (`BattlePage`, `BattleCard`, `BattleSkeleton`)
- Frontend route wiring and API client support for battle fetch + vote submission
- Backend JSON endpoints for battle pair retrieval and vote handling under `/api/v1`
- Spotify embed polish:
  - theme-aware embed switching
  - rounded-corner rendering fixes
  - loading skeleton + fade-in to prevent white flash
  - stable embed sizing to avoid layout shift
- UX and accessibility improvements:
  - keyboard interaction/focus styles
  - modal ARIA attributes
  - prevent accidental votes when clicking streaming links/embed controls
- Fixed initial pair-swapping issue on page load by deduping/guarding concurrent fetches

## Why

The battle page was not yet migrated to V2 behavior parity.  
This change delivers a production-ready V2 battle experience consistent with V1, while improving reliability (no initial pair swap), interaction correctness (no accidental votes), and accessibility.

## Linked Issue

N/A

## Type Of Change

- [x] feat
- [x] fix
- [ ] chore
- [ ] docs
- [ ] test

## Scope

- [x] Backend (app)
- [x] Frontend V2 (frontend)
- [ ] Legacy templates (templates)
- [ ] Docs / contributor workflow

## Testing

Manual verification completed:

- Opened battle page via refresh and route navigation
- Confirmed stable initial pair (no swap on first load)
- Confirmed `Skip this match` and `Next Battle` fetch new pairs
- Confirmed streaming links and Spotify embed interactions do not cast votes
- Verified Spotify embed loading skeleton/fade behavior and no card height jump
- Verified theme switching and visual consistency in dark/light

Automated checks not run yet in this session:

```bash
make lint
make test
```

## Migration / Compatibility Notes

- [x] API changes are backward-compatible, or rationale is documented.
- [x] Legacy behavior impact considered for V2 migration.
- [ ] Docs updated where needed.