### PR TITLE
feature: Song Requests Page

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,13 +1,14 @@
-from flask import Blueprint, jsonify, request, current_app, make_response
+from flask import Blueprint, jsonify, request, current_app, make_response, url_for
 from datetime import datetime, timezone
 from flask_login import login_required, current_user
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
+import json
 import requests
 
 from .. import db
-from ..models import Album, Vote, AlbumScore, VotePeriod, Song, Setting, BattleVote
-from ..utils import fetch_artist_image
+from ..models import Album, Vote, AlbumScore, VotePeriod, Song, Setting, BattleVote, SongRequest, User
+from ..utils import fetch_artist_image, search_album, send_push
 
 bp = Blueprint('api', __name__, url_prefix='/api')
 bp_v1 = Blueprint('api_v1', __name__, url_prefix='/api/v1')
@@ -1031,6 +1032,145 @@ def api_battle_vote():
             'loss': round(loser.elo_rating - Rl, 1),
         },
     })
+
+
+@bp.route('/song-requests', methods=['GET'])
+@bp_v1.route('/song-requests', methods=['GET'])
+@login_required
+def api_list_song_requests():
+    request_rows = (
+        SongRequest.query
+        .filter_by(user_id=current_user.id)
+        .order_by(SongRequest.timestamp.desc())
+        .all()
+    )
+
+    payload = [
+        {
+            'id': row.id,
+            'title': row.title,
+            'artist': row.artist,
+            'spotify_id': row.spotify_id,
+            'cover_url': row.cover_url,
+            'release_date': row.release_date,
+            'spotify_url': row.spotify_url,
+            'fulfilled': bool(row.fulfilled),
+            'timestamp': row.timestamp.isoformat() if row.timestamp else None,
+        }
+        for row in request_rows
+    ]
+
+    fulfilled = sum(1 for row in request_rows if row.fulfilled)
+    pending = len(request_rows) - fulfilled
+
+    return jsonify(
+        {
+            'requests': payload,
+            'stats': {
+                'total': len(request_rows),
+                'fulfilled': fulfilled,
+                'pending': pending,
+            },
+        }
+    )
+
+
+@bp.route('/song-requests/search', methods=['POST'])
+@bp_v1.route('/song-requests/search', methods=['POST'])
+@login_required
+def api_search_song_request_albums():
+    data = request.get_json(silent=True) or {}
+    album_query = (data.get('album_query') or '').strip()
+    if not album_query:
+        return jsonify({'error': 'album_query is required'}), 400
+
+    albums = search_album(album_query)
+
+    return jsonify(
+        {
+            'query': album_query,
+            'albums': [
+                {
+                    'id': album.get('id'),
+                    'title': album.get('name'),
+                    'artist': (album.get('artists') or [{}])[0].get('name'),
+                    'release_date': album.get('release_date'),
+                    'cover_url': (album.get('images') or [{}])[0].get('url') if album.get('images') else None,
+                    'spotify_url': (album.get('external_urls') or {}).get('spotify'),
+                }
+                for album in albums
+            ],
+        }
+    )
+
+
+@bp.route('/song-requests', methods=['POST'])
+@bp_v1.route('/song-requests', methods=['POST'])
+@login_required
+def api_create_song_request():
+    data = request.get_json(silent=True) or {}
+    title = (data.get('title') or '').strip()
+    artist = (data.get('artist') or '').strip()
+    spotify_id = (data.get('spotify_id') or '').strip()
+    cover_url = (data.get('cover_url') or '').strip()
+    release_date = (data.get('release_date') or '').strip()
+    spotify_url = (data.get('spotify_url') or '').strip()
+
+    if not title or not artist:
+        return jsonify({'error': 'Both album title and artist are required.'}), 400
+
+    req = SongRequest(
+        user_id=current_user.id,
+        title=title,
+        artist=artist,
+        spotify_id=spotify_id or None,
+        cover_url=cover_url or None,
+        release_date=release_date or None,
+        spotify_url=spotify_url or None,
+        timestamp=datetime.now(timezone.utc),
+    )
+    db.session.add(req)
+    db.session.commit()
+
+    admins = User.query.filter_by(is_admin=True).all()
+    for admin in admins:
+        if not admin.push_subscription:
+            continue
+        try:
+            subscriptions = json.loads(admin.push_subscription)
+        except Exception:
+            continue
+
+        if isinstance(subscriptions, dict):
+            subscriptions = [subscriptions]
+
+        for sub in subscriptions:
+            try:
+                send_push(
+                    subscription_info=json.dumps(sub),
+                    title='New Album Request',
+                    body=f'{current_user.username} requested "{title}" by {artist}.',
+                    url=url_for('admin.admin_song_requests', _external=True),
+                )
+            except Exception as ex:
+                current_app.logger.error(f"Web push failed: {ex}")
+
+    return jsonify(
+        {
+            'message': 'Your request has been submitted!',
+            'request': {
+                'id': req.id,
+                'title': req.title,
+                'artist': req.artist,
+                'spotify_id': req.spotify_id,
+                'cover_url': req.cover_url,
+                'release_date': req.release_date,
+                'spotify_url': req.spotify_url,
+                'fulfilled': bool(req.fulfilled),
+                'timestamp': req.timestamp.isoformat() if req.timestamp else None,
+            },
+        }
+    ), 201
 
 
 # -------- Retro voting endpoints --------

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import BattlePage from "./pages/BattlePage";
 import ResultsPage from "./pages/ResultsPage";
 import RetroHubPage from "./pages/RetroHubPage";
 import RetroVotePage from "./pages/RetroVotePage";
+import SongRequestsPage from "./pages/SongRequestsPage";
 import TopAlbumsPage from "./pages/TopAlbumsPage";
 import TopArtistsPage from "./pages/TopArtistsPage";
 import TopSongsPage from "./pages/TopSongsPage";
@@ -55,6 +56,10 @@ function parseHashRoute(hash) {
 
   if (pathOnly === "/top-songs") {
     return { page: "/top-songs", albumId: null };
+  }
+
+  if (pathOnly === "/song-requests") {
+    return { page: "/song-requests", albumId: null };
   }
 
   if (pathOnly === "/retro-hub") {
@@ -182,6 +187,10 @@ function App() {
 
         {route.page === "/top-songs" && sessionState !== "loading" && sessionState !== "error" ? (
           <TopSongsPage />
+        ) : null}
+
+        {sessionState === "authenticated" && route.page === "/song-requests" ? (
+          <SongRequestsPage />
         ) : null}
 
         {sessionState === "authenticated" && route.page === "/vote" ? (

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -193,6 +193,24 @@ export function submitBattleVote(payload) {
   });
 }
 
+export function getSongRequests() {
+  return request("/api/v1/song-requests");
+}
+
+export function searchSongRequestAlbums(albumQuery) {
+  return request("/api/v1/song-requests/search", {
+    method: "POST",
+    body: JSON.stringify({ album_query: albumQuery }),
+  });
+}
+
+export function submitSongRequest(payload) {
+  return request("/api/v1/song-requests", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
 export function legacyLoginHref() {
   return buildUrl("/legacy/login");
 }

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -143,7 +143,7 @@ export default function Header({
           <div className="nav-group user-group">
             {sessionState === "authenticated" ? (
               <>
-                <a href={legacyPageHref("/song-requests")} className="nav-btn request-btn" onClick={closeMobileOverlays}>
+                <a href="#/song-requests" className={`nav-btn request-btn ${route === "/song-requests" ? "active" : ""}`} onClick={closeMobileOverlays}>
                   <PlusCircleIcon className="icon-left" />
                   Request
                 </a>

--- a/frontend/src/pages/SongRequestsPage.css
+++ b/frontend/src/pages/SongRequestsPage.css
@@ -1,0 +1,251 @@
+.sr-search-card,
+.sr-results-card,
+.sr-stats-card {
+  display: grid;
+  gap: 1rem;
+  border-radius: 14px;
+  background:
+    radial-gradient(circle at 100% -25%, color-mix(in oklab, var(--accent) 9%, transparent), transparent 48%),
+    var(--card-bg);
+}
+
+.sr-search-card h2,
+.sr-results-card h2,
+.sr-stats-card h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.7vw, 1.55rem);
+  letter-spacing: -0.02em;
+}
+
+.sr-search-form {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.sr-search-form label {
+  font-weight: 700;
+  font-size: 1.02rem;
+}
+
+.sr-search-row {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: 1fr auto;
+  align-items: stretch;
+}
+
+.sr-search-row input {
+  width: 100%;
+  min-height: 42px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in oklab, var(--accent) 16%, var(--border-color));
+  background: color-mix(in oklab, var(--bg) 92%, var(--card-bg));
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.sr-search-row input:focus-visible {
+  outline: none;
+  border-color: color-mix(in oklab, var(--accent) 62%, var(--border-color));
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 26%, transparent);
+}
+
+.sr-search-row .btn {
+  min-height: 42px;
+  border-radius: 10px;
+  font-weight: 700;
+  min-width: 92px;
+}
+
+.sr-help {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.sr-results-grid,
+.sr-requests-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 0.9rem;
+}
+
+.sr-album-card,
+.sr-request-card {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background:
+    linear-gradient(180deg, color-mix(in oklab, var(--card-bg) 95%, transparent), color-mix(in oklab, var(--bg) 89%, var(--card-bg)));
+  padding: 0.9rem;
+  display: grid;
+  gap: 0.62rem;
+  align-content: start;
+  transition: transform 0.16s ease, box-shadow 0.2s ease, border-color 0.16s ease;
+}
+
+.sr-album-card:hover,
+.sr-request-card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in oklab, var(--accent) 30%, var(--border-color));
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.22);
+}
+
+.sr-request-card {
+  grid-template-columns: 80px 1fr;
+  align-items: start;
+  gap: 0.75rem;
+}
+
+.sr-request-card.fulfilled {
+  border-color: color-mix(in oklab, var(--success-color) 45%, var(--border-color));
+}
+
+.sr-cover {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
+}
+
+.sr-request-card .sr-cover {
+  width: 80px;
+}
+
+.sr-cover-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  color: color-mix(in oklab, var(--muted) 72%, var(--accent));
+  background: color-mix(in oklab, var(--bg) 84%, var(--card-bg));
+}
+
+.sr-album-card h3,
+.sr-request-content h3 {
+  margin: 0;
+  font-size: 1.07rem;
+  line-height: 1.22;
+  letter-spacing: -0.01em;
+}
+
+.sr-artist {
+  margin: 0;
+  color: var(--text);
+  opacity: 0.82;
+  font-weight: 600;
+}
+
+.sr-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.sr-request-content {
+  display: grid;
+  gap: 0.38rem;
+}
+
+.sr-request-footer {
+  margin-top: 0.45rem;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.7rem;
+}
+
+.sr-request-footer .streaming-links {
+  margin-top: 0;
+}
+
+.sr-request-footer .stream-btn {
+  padding: 0.34rem 0.44rem;
+}
+
+.sr-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  padding: 0.16rem 0.58rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.sr-badge.ok {
+  color: var(--success-color);
+  border-color: color-mix(in oklab, var(--success-color) 60%, var(--border-color));
+  background: color-mix(in oklab, var(--success-color) 8%, transparent);
+}
+
+.sr-badge.wait {
+  color: color-mix(in oklab, #d69a00 76%, var(--text));
+  border-color: color-mix(in oklab, #d69a00 42%, var(--border-color));
+  background: color-mix(in oklab, #d69a00 12%, transparent);
+}
+
+.sr-stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.sr-stat {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 0.72rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.2rem;
+  background:
+    linear-gradient(180deg, color-mix(in oklab, var(--bg) 82%, var(--card-bg)), color-mix(in oklab, var(--bg) 90%, var(--card-bg)));
+}
+
+.sr-stat-value {
+  font-size: 1.52rem;
+  font-weight: 800;
+  color: var(--accent);
+  line-height: 1;
+}
+
+.sr-stat-label {
+  font-size: 0.76rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.sr-empty {
+  margin: 0;
+  color: var(--muted);
+  padding: 0.35rem 0;
+}
+
+@media (max-width: 720px) {
+  .sr-search-card,
+  .sr-results-card,
+  .sr-stats-card {
+    gap: 0.86rem;
+  }
+
+  .sr-search-row {
+    grid-template-columns: 1fr;
+  }
+
+  .sr-search-row .btn {
+    width: 100%;
+  }
+
+  .sr-stats-row {
+    grid-template-columns: 1fr;
+  }
+
+  .sr-request-card {
+    grid-template-columns: 1fr;
+  }
+
+  .sr-request-card .sr-cover {
+    width: 100%;
+  }
+}

--- a/frontend/src/pages/SongRequestsPage.jsx
+++ b/frontend/src/pages/SongRequestsPage.jsx
@@ -1,0 +1,228 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  getSongRequests,
+  searchSongRequestAlbums,
+  submitSongRequest,
+} from "../api";
+import StatusCard from "../components/common/StatusCard";
+import StreamingLinks from "../components/common/StreamingLinks";
+import "./SongRequestsPage.css";
+
+function formatRequestTime(timestamp) {
+  if (!timestamp) return "Unknown";
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleString();
+}
+
+export default function SongRequestsPage() {
+  const [query, setQuery] = useState("");
+  const [searchState, setSearchState] = useState("idle");
+  const [searchError, setSearchError] = useState(null);
+  const [searchResults, setSearchResults] = useState([]);
+  const [requestsState, setRequestsState] = useState("loading");
+  const [requestsError, setRequestsError] = useState(null);
+  const [requests, setRequests] = useState([]);
+  const [stats, setStats] = useState({ total: 0, fulfilled: 0, pending: 0 });
+  const [submittingKey, setSubmittingKey] = useState(null);
+  const [successMessage, setSuccessMessage] = useState("");
+
+  useEffect(() => {
+    loadRequests();
+  }, []);
+
+  async function loadRequests() {
+    setRequestsState("loading");
+    setRequestsError(null);
+    try {
+      const payload = await getSongRequests();
+      setRequests(payload.requests || []);
+      setStats(payload.stats || { total: 0, fulfilled: 0, pending: 0 });
+      setRequestsState((payload.requests || []).length ? "ready" : "empty");
+    } catch (err) {
+      setRequestsError(err.message || String(err));
+      setRequestsState("error");
+    }
+  }
+
+  async function onSearchSubmit(event) {
+    event.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+
+    setSuccessMessage("");
+    setSearchError(null);
+    setSearchState("loading");
+
+    try {
+      const payload = await searchSongRequestAlbums(trimmed);
+      const albums = payload.albums || [];
+      setSearchResults(albums);
+      setSearchState(albums.length ? "ready" : "empty");
+    } catch (err) {
+      setSearchError(err.message || String(err));
+      setSearchState("error");
+    }
+  }
+
+  async function onRequestAlbum(album) {
+    const key = album.id || `${album.title}-${album.artist}`;
+    setSubmittingKey(key);
+    setSearchError(null);
+    setSuccessMessage("");
+
+    try {
+      await submitSongRequest({
+        title: album.title,
+        artist: album.artist,
+        spotify_id: album.id,
+        cover_url: album.cover_url,
+        release_date: album.release_date,
+        spotify_url: album.spotify_url,
+      });
+
+      setSuccessMessage(`Requested "${album.title}" by ${album.artist}.`);
+      setSearchResults([]);
+      setSearchState("idle");
+      setQuery("");
+      await loadRequests();
+    } catch (err) {
+      setSearchError(err.message || String(err));
+    } finally {
+      setSubmittingKey(null);
+    }
+  }
+
+  const requestCards = useMemo(
+    () =>
+      requests.map((req) => (
+        <article key={req.id} className={`sr-request-card ${req.fulfilled ? "fulfilled" : "pending"}`}>
+          {req.cover_url ? (
+            <img className="sr-cover" src={req.cover_url} alt={`${req.title} cover`} loading="lazy" />
+          ) : (
+            <div className="sr-cover sr-cover-placeholder" aria-hidden="true">♪</div>
+          )}
+
+          <div className="sr-request-content">
+            <h3>{req.title}</h3>
+            <p className="sr-artist">{req.artist}</p>
+            {req.release_date ? <p className="sr-meta">Released: {req.release_date}</p> : null}
+            <p className="sr-meta">Requested: {formatRequestTime(req.timestamp)}</p>
+
+            <div className="sr-request-footer">
+              <span className={`sr-badge ${req.fulfilled ? "ok" : "wait"}`}>
+                {req.fulfilled ? "Fulfilled" : "Pending"}
+              </span>
+              {req.spotify_url ? (
+                <StreamingLinks spotifyUrl={req.spotify_url} mode="icons" />
+              ) : null}
+            </div>
+          </div>
+        </article>
+      )),
+    [requests],
+  );
+
+  return (
+    <>
+      <section className="hero">
+        <p className="eyebrow">Vinyl Vote V2</p>
+        <h1>Album Requests</h1>
+        <p className="subtitle">Search Spotify, submit requests, and track what has been fulfilled.</p>
+      </section>
+
+      <section className="card sr-search-card">
+        <h2>Request an album</h2>
+        <form className="sr-search-form" onSubmit={onSearchSubmit}>
+          <label htmlFor="albumQuery">Search for an album</label>
+          <div className="sr-search-row">
+            <input
+              id="albumQuery"
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="e.g. Blonde Frank Ocean"
+              required
+              aria-describedby="sr-query-help"
+            />
+            <button type="submit" className="btn btn-primary" disabled={searchState === "loading"}>
+              {searchState === "loading" ? "Searching..." : "Search"}
+            </button>
+          </div>
+          <p id="sr-query-help" className="sr-help">Pick the correct result below and submit it.</p>
+        </form>
+      </section>
+
+      {successMessage ? <StatusCard title="Request sent" message={successMessage} /> : null}
+      {searchState === "error" ? <StatusCard title="Search failed" message={searchError} variant="error" /> : null}
+
+      {searchState === "ready" || searchState === "empty" ? (
+        <section className="card sr-results-card">
+          <h2>Search Results</h2>
+          {searchState === "empty" ? (
+            <p className="sr-empty">No albums found. Try a different search.</p>
+          ) : (
+            <div className="sr-results-grid">
+              {searchResults.map((album) => {
+                const key = album.id || `${album.title}-${album.artist}`;
+                const isSubmitting = submittingKey === key;
+                return (
+                  <article key={key} className="sr-album-card">
+                    {album.cover_url ? (
+                      <img className="sr-cover" src={album.cover_url} alt={`${album.title} cover`} loading="lazy" />
+                    ) : (
+                      <div className="sr-cover sr-cover-placeholder" aria-hidden="true">♪</div>
+                    )}
+                    <h3>{album.title}</h3>
+                    <p className="sr-artist">{album.artist}</p>
+                    {album.release_date ? <p className="sr-meta">Released: {album.release_date}</p> : null}
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      disabled={!!submittingKey}
+                      onClick={() => onRequestAlbum(album)}
+                    >
+                      {isSubmitting ? "Requesting..." : "Request this album"}
+                    </button>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      ) : null}
+
+      <section className="card sr-stats-card">
+        <h2>Your requests</h2>
+
+        {requestsState === "loading" ? <p className="sr-empty">Loading your requests...</p> : null}
+        {requestsState === "error" ? <StatusCard title="Could not load requests" message={requestsError} variant="error" /> : null}
+
+        {requestsState === "ready" || requestsState === "empty" ? (
+          <>
+            <div className="sr-stats-row" aria-label="request stats">
+              <div className="sr-stat">
+                <span className="sr-stat-value">{stats.total}</span>
+                <span className="sr-stat-label">Total</span>
+              </div>
+              <div className="sr-stat">
+                <span className="sr-stat-value">{stats.fulfilled}</span>
+                <span className="sr-stat-label">Fulfilled</span>
+              </div>
+              <div className="sr-stat">
+                <span className="sr-stat-value">{stats.pending}</span>
+                <span className="sr-stat-label">Pending</span>
+              </div>
+            </div>
+
+            {requestsState === "empty" ? (
+              <p className="sr-empty">You have not submitted any requests yet.</p>
+            ) : (
+              <div className="sr-requests-grid">{requestCards}</div>
+            )}
+          </>
+        ) : null}
+      </section>
+    </>
+  );
+}

--- a/tests/test_api_v1_contracts.py
+++ b/tests/test_api_v1_contracts.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from flask import Flask
 
 from app import db, login_manager
-from app.models import Album, AlbumScore, BattleVote, Setting, Song, User, Vote, VotePeriod
+from app.models import Album, AlbumScore, BattleVote, Setting, Song, SongRequest, User, Vote, VotePeriod
 from app.routes import api
 
 
@@ -475,6 +475,97 @@ def test_battle_vote_rejects_same_winner_and_loser_ids():
         assert song_after.elo_rating == elo_before
         assert song_after.match_count == match_before
         assert vote_count == 0
+
+    with app.app_context():
+        db.drop_all()
+
+
+def test_song_requests_list_and_create_contract():
+    app = _build_app()
+    with app.app_context():
+        db.create_all()
+
+    user_id = _seed_authenticated_user_and_album(app)
+    client = app.test_client()
+    _login(client, user_id)
+
+    initial = client.get("/api/v1/song-requests")
+    assert initial.status_code == 200
+    assert initial.get_json() == {
+        "requests": [],
+        "stats": {"total": 0, "fulfilled": 0, "pending": 0},
+    }
+
+    invalid = client.post("/api/v1/song-requests", json={"title": "", "artist": ""})
+    assert invalid.status_code == 400
+    assert invalid.get_json() == {"error": "Both album title and artist are required."}
+
+    create_payload = {
+        "title": "Discovery",
+        "artist": "Daft Punk",
+        "spotify_id": "abc123",
+        "cover_url": "https://example.com/discovery.jpg",
+        "release_date": "2001-03-07",
+        "spotify_url": "https://open.spotify.com/album/abc123",
+    }
+    created = client.post("/api/v1/song-requests", json=create_payload)
+    assert created.status_code == 201
+    created_json = created.get_json()
+    assert created_json["message"] == "Your request has been submitted!"
+    assert created_json["request"]["title"] == "Discovery"
+    assert created_json["request"]["artist"] == "Daft Punk"
+    assert created_json["request"]["fulfilled"] is False
+
+    after = client.get("/api/v1/song-requests")
+    assert after.status_code == 200
+    after_payload = after.get_json()
+    assert after_payload["stats"] == {"total": 1, "fulfilled": 0, "pending": 1}
+    assert len(after_payload["requests"]) == 1
+    assert after_payload["requests"][0]["title"] == "Discovery"
+
+    with app.app_context():
+        db.drop_all()
+
+
+def test_song_requests_search_contract_and_validation():
+    app = _build_app()
+    with app.app_context():
+        db.create_all()
+
+    user_id = _seed_authenticated_user_and_album(app)
+    client = app.test_client()
+    _login(client, user_id)
+
+    invalid = client.post("/api/v1/song-requests/search", json={"album_query": ""})
+    assert invalid.status_code == 400
+    assert invalid.get_json() == {"error": "album_query is required"}
+
+    mocked_albums = [
+        {
+            "id": "spotify-album-1",
+            "name": "Random Access Memories",
+            "artists": [{"name": "Daft Punk"}],
+            "release_date": "2013-05-17",
+            "images": [{"url": "https://example.com/ram.jpg"}],
+            "external_urls": {"spotify": "https://open.spotify.com/album/spotify-album-1"},
+        }
+    ]
+
+    with patch("app.routes.api.search_album", return_value=mocked_albums):
+        response = client.post("/api/v1/song-requests/search", json={"album_query": "daft punk ram"})
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["query"] == "daft punk ram"
+    assert len(payload["albums"]) == 1
+    assert payload["albums"][0] == {
+        "id": "spotify-album-1",
+        "title": "Random Access Memories",
+        "artist": "Daft Punk",
+        "release_date": "2013-05-17",
+        "cover_url": "https://example.com/ram.jpg",
+        "spotify_url": "https://open.spotify.com/album/spotify-album-1",
+    }
 
     with app.app_context():
         db.drop_all()


### PR DESCRIPTION
## Summary

Implemented a new V2 Song Requests screen at `#/song-requests` that matches legacy behavior while improving UI consistency and usability.

Key updates:
- Added a full V2 Song Requests page with:
  - Spotify album search
  - request submission flow
  - user request history with fulfilled/pending status
  - request stats (total/fulfilled/pending)
- Wired header navigation Request button to the V2 route.
- Replaced text-based Spotify link in request cards with the shared streaming service icon buttons.
- Improved styling and responsive behavior to align with existing V2 visual patterns.

Backend/API updates:
- Added authenticated JSON endpoints for V2:
  - `GET /api/v1/song-requests`
  - `POST /api/v1/song-requests/search`
  - `POST /api/v1/song-requests`
- Preserved legacy parity for core behavior (search, create request, list personal requests, admin push notifications).

## Why

The Request flow was still legacy-rendered and visually inconsistent with V2 pages.  
This change moves Song Requests into the V2 app, keeps behavior familiar for users, improves maintainability, and aligns the experience with the current React-based UI patterns.

## Linked Issue

N/A

## Type Of Change

- [x] feat
- [x] fix
- [ ] chore
- [ ] docs
- [x] test

## Scope

- [x] Backend (app/)
- [x] Frontend V2 (frontend/)
- [ ] Legacy templates (app/templates/)
- [ ] Docs / contributor workflow

## Testing

Ran and passed:

```bash
make lint
make test
```

Additional targeted/verification runs:
- `poetry run pytest test_api_v1_contracts.py -k "song_requests"`
- `poetry run pytest test_api_v1_contracts.py -k "song_requests or battle"`
- `cd frontend && npm run build`

Result:
- Lint passed
- Test suite passed
- Frontend build passed

## Migration / Compatibility Notes

- [x] API changes are backward-compatible, or rationale is documented.
- [x] Legacy behavior impact considered for V2 migration.
- [ ] Docs updated where needed.