### PR TITLE
Feature/prod docker browserrouter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ __pycache__
 .env
 temp/
 extension/
+frontend/node_modules/
+frontend/dist/

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Flask Configuration
 SECRET_KEY=your-secret-key-here
 
+# Production host port for frontend container (docker-compose.prod.yml)
+# Use any free port on this server, for example 8088.
+FRONTEND_HOST_PORT=8088
+
+# Public base URL used in frontend SEO metadata (canonical/OG tags)
+# Do not include trailing slash.
+PUBLIC_SITE_URL=https://vinylvote.example
+
 # Database
 # SQLite is used by default (configured in config.py)
 # SQLALCHEMY_DATABASE_URI=sqlite:///album_vote.db
@@ -39,6 +47,11 @@ KEYN_DEFAULT_SCOPES=id,username,email,display_name,is_verified
 FORCE_KEYN_REGISTRATION=false
 FORCE_KEYN_LOGIN=false
 
+# Optional explicit profile/manage URLs (defaults are derived from KEYN_AUTH_SERVER_URL)
+# KEYN_PROFILE_URL=https://auth-keyn.bynolo.ca/profile
+# KEYN_EDIT_PROFILE_URL=https://auth-keyn.bynolo.ca/profile/edit
+# KEYN_CHANGE_PASSWORD_URL=https://auth-keyn.bynolo.ca/profile/change-password
+
 # Dev auth bypass (local development only)
 DEV_AUTH_BYPASS=false
 DEV_AUTH_BYPASS_DEFAULT_USERNAME=dev-user
@@ -49,8 +62,19 @@ NOLOFICATION_URL=https://nolofication.bynolo.ca
 NOLOFICATION_SITE_ID=vinylvote
 NOLOFICATION_API_KEY=your-nolofication-api-key-here
 
+# Optional explicit preferences URL (default derives from NOLOFICATION_URL + NOLOFICATION_SITE_ID)
+# NOLOFICATION_PREFERENCES_URL=https://nolofication.bynolo.ca/sites/vinylvote/preferences
+
+# Public extension store/listing URL
+CHROME_EXTENSION_STORE_URL=https://chrome.google.com/webstore/detail/nmknoocoofipjkkhfgameiinddigekpb
+
 # Session/Cookie Settings
 REMEMBER_COOKIE_SECURE=False  # Set to True in production with HTTPS
+SESSION_COOKIE_SECURE=False   # Set to True in production with HTTPS
+
+# Startup migration behavior for production containers
+# Web should run migrations on boot, scheduler should not.
+# RUN_MIGRATIONS_ON_START=true
 
 # Optional deploy-time cache busting
 # ASSET_VERSION=202604040001

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ FROM python:3.11-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+ENV FLASK_ENV=production
 
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential \
+  && apt-get install -y --no-install-recommends build-essential curl gosu \
     && rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --system app && adduser --system --ingroup app --home /app app
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt \
@@ -15,6 +18,16 @@ RUN pip install --no-cache-dir -r requirements.txt \
 
 COPY . .
 
+RUN chown -R app:app /app
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
 EXPOSE 5000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:5000/health || exit 1
 
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "run:app"]

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,6 @@ dev-stack:
 dev-stack-detached:
 	docker compose up -d --build
 	@echo "Docker services started. Run 'cd frontend && npm run dev' to start the frontend dev server."
+
+prod-deploy:
+	docker compose -f docker-compose.prod.yml up -d --build

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ docker compose up --build
 
 See `docs/PROXMOX_DEPLOY.md` for deployment flow and `docker-compose.yml` for local services.
 
+Production stack (frontend + backend + scheduler):
+
+```bash
+export FRONTEND_HOST_PORT=8088
+mkdir -p db
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+Use any free host port instead of `80`.
+
+The production stack bind-mounts SQLite data to the repository-local `db/` folder so the existing database is easy to inspect, back up, and migrate.
+
 ## Developer Commands
 
 With virtualenv active:
@@ -116,6 +128,16 @@ KEYN_CLIENT_ID=your_client_id
 KEYN_CLIENT_SECRET=your_client_secret
 KEYN_CLIENT_REDIRECT=http://127.0.0.1:5000/oauth/callback
 KEYN_DEFAULT_SCOPES=id,username,email,display_name,is_verified
+```
+
+Optional overrides for centralized profile/manage links:
+
+```text
+KEYN_PROFILE_URL=https://auth-keyn.bynolo.ca/profile
+KEYN_EDIT_PROFILE_URL=https://auth-keyn.bynolo.ca/profile/edit
+KEYN_CHANGE_PASSWORD_URL=https://auth-keyn.bynolo.ca/profile/change-password
+NOLOFICATION_PREFERENCES_URL=https://nolofication.bynolo.ca/sites/vinylvote/preferences
+CHROME_EXTENSION_STORE_URL=https://chrome.google.com/webstore/detail/nmknoocoofipjkkhfgameiinddigekpb
 ```
 
 Auth defaults in V2 migration:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from config import Config
@@ -190,6 +190,10 @@ def create_app():
     def inject_asset_version():
         # Expose asset version for cache-busting in templates
         return {'asset_version': app.config.get('ASSET_VERSION', '1')}
+
+    @app.get('/health')
+    def health_check():
+        return jsonify({'status': 'ok'}), 200
 
     @app.errorhandler(401)
     def unauthorized(e):

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -964,7 +964,7 @@ def _build_profile_payload():
                 'songs': songs_payload,
                 'album_score': album_score_map.get(album.id),
                 'song_score': avg_song_score,
-                'results_href': f"#/results/{album.id}",
+                'results_href': f"/results/{album.id}",
                 'vote_card_href': url_for('user.share_vote_card', album_id=album.id),
             }
         )

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1015,10 +1015,10 @@ def _build_profile_payload():
         },
         'album_votes': album_votes,
         'keyn_links': {
-            'profile': 'https://auth-keyn.bynolo.ca/profile',
-            'edit_profile': 'https://auth-keyn.bynolo.ca/profile/edit',
-            'change_password': 'https://auth-keyn.bynolo.ca/profile/change-password',
-            'notifications': 'https://nolofication.bynolo.ca/sites/vinylvote/preferences',
+            'profile': current_app.config.get('KEYN_PROFILE_URL'),
+            'edit_profile': current_app.config.get('KEYN_EDIT_PROFILE_URL'),
+            'change_password': current_app.config.get('KEYN_CHANGE_PASSWORD_URL'),
+            'notifications': current_app.config.get('NOLOFICATION_PREFERENCES_URL'),
         },
     }
 

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -257,7 +257,7 @@ def sitemap_xml():
 @bp.route('/extension')
 def extension():
     """Open the chrome web store page for the extension in a new tab."""
-    return redirect("https://chrome.google.com/webstore/detail/nmknoocoofipjkkhfgameiinddigekpb", code=302)
+    return redirect(current_app.config.get('CHROME_EXTENSION_STORE_URL'), code=302)
 
 # VAPID keys are used for web push notifications
 @bp.route('/vapid-public-key')
@@ -1530,7 +1530,7 @@ def profile():
         last_vote_iso = None
     profile_extras = { 'active_weeks': active_weeks, 'last_on_time_vote': last_vote_label, 'last_on_time_vote_full': last_vote_full, 'last_on_time_vote_iso': last_vote_iso }
 
-    keyn_auth_server_url = current_app.config.get('KEYN_AUTH_SERVER_URL', 'https://auth-keyn.bynolo.ca')
+    keyn_auth_server_url = current_app.config.get('KEYN_AUTH_SERVER_URL')
     keyn_profile = None
     if current_user.keyn_migrated and current_user.keyn_profile_json:
         import json

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, Response, render_template, redirect, url_for, flash, request, session
+from flask import Blueprint, Response, render_template, redirect, url_for, flash, request, session, make_response
 from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime
@@ -490,11 +490,38 @@ def _legacy_register_flow():
         force_keyn_login=current_app.config.get('FORCE_KEYN_LOGIN', False),
     )
 
-@bp.route('/logout')
-@login_required
+@bp.route('/logout', methods=['GET', 'POST'])
 def logout():
+    """Log out user and clear all session/auth cookies."""
     logout_user()
-    return redirect(url_for('user.index'))
+    session.clear()
+
+    # Create response with redirect
+    response = make_response(redirect(url_for('user.index')))
+
+    # Explicitly expire session cookies with both max_age and expires for maximum compatibility
+    expires = 'Thu, 01 Jan 1970 00:00:00 GMT'
+    
+    response.set_cookie(
+        'remember_token',
+        '',
+        max_age=0,
+        expires=expires,
+        path='/',
+        samesite='Lax',
+        httponly=True,
+    )
+    response.set_cookie(
+        'session',
+        '',
+        max_age=0,
+        expires=expires,
+        path='/',
+        samesite='Lax',
+        httponly=True,
+    )
+
+    return response
 
 @bp.route('/update_email', methods=['POST'])
 @login_required

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ class Config:
     REMEMBER_COOKIE_SECURE = os.environ.get('REMEMBER_COOKIE_SECURE', 'False').lower() == 'true'
     REMEMBER_COOKIE_HTTPONLY = True
     REMEMBER_COOKIE_SAMESITE = 'Lax'  # Better for mobile web apps
+    SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'False').lower() == 'true'
     SESSION_COOKIE_SAMESITE = 'Lax'   # Better for mobile web apps
     ENABLE_SCHEDULER = os.getenv('ENABLE_SCHEDULER', 'True').lower() == 'true'
 
@@ -65,10 +66,22 @@ class Config:
     DEV_AUTH_BYPASS = os.environ.get('DEV_AUTH_BYPASS', 'false').lower() in ('1', 'true', 'yes')
     DEV_AUTH_BYPASS_DEFAULT_USERNAME = os.environ.get('DEV_AUTH_BYPASS_DEFAULT_USERNAME', 'dev-user')
 
+    # Centralized KeyN profile/manage links (override if your KeyN host differs)
+    KEYN_PROFILE_URL = os.getenv('KEYN_PROFILE_URL') or f"{KEYN_AUTH_SERVER_URL.rstrip('/')}/profile"
+    KEYN_EDIT_PROFILE_URL = os.getenv('KEYN_EDIT_PROFILE_URL') or f"{KEYN_AUTH_SERVER_URL.rstrip('/')}/profile/edit"
+    KEYN_CHANGE_PASSWORD_URL = os.getenv('KEYN_CHANGE_PASSWORD_URL') or f"{KEYN_AUTH_SERVER_URL.rstrip('/')}/profile/change-password"
+
     # --- Nolofication settings ---
     NOLOFICATION_URL = os.getenv('NOLOFICATION_URL', 'https://nolofication.bynolo.ca')
     NOLOFICATION_SITE_ID = os.getenv('NOLOFICATION_SITE_ID', 'vinylvote')
     NOLOFICATION_API_KEY = os.getenv('NOLOFICATION_API_KEY')
+    NOLOFICATION_PREFERENCES_URL = os.getenv('NOLOFICATION_PREFERENCES_URL') or f"{NOLOFICATION_URL.rstrip('/')}/sites/{NOLOFICATION_SITE_ID}/preferences"
+
+    # Public extension listing link
+    CHROME_EXTENSION_STORE_URL = os.getenv(
+        'CHROME_EXTENSION_STORE_URL',
+        'https://chrome.google.com/webstore/detail/nmknoocoofipjkkhfgameiinddigekpb'
+    )
 
     @staticmethod
     def get_vote_end_time():

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,47 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: vinyl-vote-web:prod
+    env_file:
+      - .env
+    environment:
+      ENABLE_SCHEDULER: "false"
+      RUN_MIGRATIONS_ON_START: "true"
+      SESSION_COOKIE_SECURE: "true"
+      REMEMBER_COOKIE_SECURE: "true"
+      SQLALCHEMY_DATABASE_URI: sqlite:////app/data/album_vote.db
+    volumes:
+      - ./db:/app/data
+    restart: unless-stopped
+
+  scheduler:
+    image: vinyl-vote-web:prod
+    env_file:
+      - .env
+    environment:
+      ENABLE_SCHEDULER: "true"
+      RUN_MIGRATIONS_ON_START: "false"
+      SESSION_COOKIE_SECURE: "true"
+      REMEMBER_COOKIE_SECURE: "true"
+      SQLALCHEMY_DATABASE_URI: sqlite:////app/data/album_vote.db
+    command: ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "run:app"]
+    depends_on:
+      - web
+    volumes:
+      - ./db:/app/data
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-http://localhost}
+    image: vinyl-vote-frontend:prod
+    ports:
+      - "${FRONTEND_HOST_PORT:-8088}:8080"
+    depends_on:
+      - web
+    restart: unless-stopped

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+mkdir -p /app/data
+chown -R app:app /app/data
+
+if [ "${RUN_MIGRATIONS_ON_START:-true}" = "true" ]; then
+  set +e
+  MIGRATION_OUTPUT=$(gosu app flask --app run.py db upgrade 2>&1)
+  MIGRATION_STATUS=$?
+  set -e
+
+  if [ "$MIGRATION_STATUS" -ne 0 ]; then
+    echo "$MIGRATION_OUTPUT" >&2
+    echo "Migration failed on startup; continuing app boot to preserve availability." >&2
+  fi
+fi
+
+exec gosu app "$@"

--- a/docs/PROXMOX_DEPLOY.md
+++ b/docs/PROXMOX_DEPLOY.md
@@ -8,6 +8,7 @@ This document defines a practical GitHub Actions -> SSH -> Docker Compose deploy
 2. Create deploy path, for example `/opt/vinyl-vote`.
 3. Clone repository to deploy path.
 4. Add `.env` on server with production secrets.
+5. Ensure a writable `db/` folder exists beside `docker-compose.prod.yml` (the stack bind-mounts SQLite there).
 
 ## GitHub Secrets
 
@@ -25,7 +26,10 @@ On server:
 
 ```bash
 cd /opt/vinyl-vote
-docker compose up -d --build
+# choose any free host port for frontend (example: 8088)
+export FRONTEND_HOST_PORT=8088
+export PUBLIC_SITE_URL=https://vinylvote.yourdomain.com
+docker compose -f docker-compose.prod.yml up -d --build
 ```
 
 ## Continuous Deploy
@@ -43,9 +47,30 @@ On `main` push (or manual dispatch), GitHub Actions will:
 
 Terminate TLS at your reverse proxy (Nginx/Caddy/Traefik) and forward to app container:
 
-- upstream: `http://127.0.0.1:5000`
+- upstream: `http://127.0.0.1:<FRONTEND_HOST_PORT>`
 - enforce HTTPS
 - set secure headers
+
+`docker-compose.prod.yml` serves the React frontend at `${FRONTEND_HOST_PORT}` (default `8088`) and proxies API/auth routes to backend.
+BrowserRouter deep links are handled by the frontend nginx fallback to `index.html`.
+Frontend SEO tags in `frontend/index.html` are built from `PUBLIC_SITE_URL`.
+
+## Cloudflare Tunnel (Separate Host)
+
+If your Cloudflare Tunnel runs on a different server in your LAN, point the tunnel ingress to this app server:
+
+- `http://<VINYL_VOTE_LAN_IP>:<FRONTEND_HOST_PORT>`
+
+Example ingress target:
+
+```yaml
+ingress:
+	- hostname: vinylvote.yourdomain.com
+		service: http://192.168.1.50:8088
+	- service: http_status:404
+```
+
+Use your app server LAN IP and the same `FRONTEND_HOST_PORT` value from `.env`.
 
 ## Rollback
 
@@ -55,12 +80,55 @@ If deployment fails:
 cd /opt/vinyl-vote
 git log --oneline -n 5
 git reset --hard <last-good-commit>
-docker compose up -d --build
+docker compose -f docker-compose.prod.yml up -d --build
 ```
 
 ## Hardening Checklist
 
 - Set `REMEMBER_COOKIE_SECURE=true`
+- Set `SESSION_COOKIE_SECURE=true`
 - Ensure strong `SECRET_KEY`
 - Rotate VAPID and API keys if previously exposed
 - Restrict SSH key to deploy-only host/user
+
+## Production Compose Notes
+
+- Stack file: `docker-compose.prod.yml`
+- Services: `frontend`, `web`, `scheduler`
+- Scheduler runs in its own container (`ENABLE_SCHEDULER=true`) while `web` keeps scheduler off (`ENABLE_SCHEDULER=false`)
+- SQLite database file is persisted in the host `db/` folder
+- Frontend host port is configurable with `FRONTEND_HOST_PORT` (default `8088`)
+- If you terminate TLS before the container, keep secure cookie flags enabled
+- Web container runs `flask db upgrade` on startup by default (`RUN_MIGRATIONS_ON_START=true`)
+
+## Centralized URL Configuration
+
+Configure external/manage URLs in `.env` instead of editing code:
+
+- `KEYN_AUTH_SERVER_URL`
+- `KEYN_PROFILE_URL` (optional override)
+- `KEYN_EDIT_PROFILE_URL` (optional override)
+- `KEYN_CHANGE_PASSWORD_URL` (optional override)
+- `NOLOFICATION_URL`
+- `NOLOFICATION_SITE_ID`
+- `NOLOFICATION_PREFERENCES_URL` (optional override)
+- `CHROME_EXTENSION_STORE_URL`
+
+## Troubleshooting 500 on `/api/v1/*`
+
+If frontend loads but API routes return 500:
+
+1. Check logs:
+
+```bash
+docker compose -f docker-compose.prod.yml logs --tail=200 web
+docker compose -f docker-compose.prod.yml logs --tail=120 scheduler
+```
+
+2. If you see `sqlite3.OperationalError: unable to open database file`, check that the host `db/` folder exists and is writable, then rebuild and restart:
+
+```bash
+docker compose -f docker-compose.prod.yml down
+mkdir -p db
+docker compose -f docker-compose.prod.yml up -d --build
+```

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+ARG VITE_PUBLIC_SITE_URL=http://localhost
+ENV VITE_PUBLIC_SITE_URL=$VITE_PUBLIC_SITE_URL
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -33,6 +33,8 @@ By default, Vite proxies backend routes to `http://127.0.0.1:5000` for local dev
 
 You can also set `VITE_API_BASE_URL` to point to a separate backend host.
 
+For production builds, set `PUBLIC_SITE_URL` in the root `.env` (or pass it as a Docker build arg) so `index.html` can stamp canonical, Open Graph, and Twitter card URLs correctly.
+
 Example:
 
 ```bash

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,19 +12,19 @@
     <meta property="og:site_name" content="Vinyl Vote" />
     <meta property="og:title" content="Vinyl Vote | Weekly Album Voting Community" />
     <meta property="og:description" content="Rate this week's album, explore leaderboard results, and join a community of dedicated listeners." />
-    <meta property="og:image" content="https://vinylvote.example/static/favicon_64x64.png" />
-    <meta property="og:url" content="https://vinylvote.example/" />
+    <meta property="og:image" content="%VITE_PUBLIC_SITE_URL%/static/favicon_64x64.png" />
+    <meta property="og:url" content="%VITE_PUBLIC_SITE_URL%/" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Vinyl Vote | Weekly Album Voting Community" />
     <meta name="twitter:description" content="Rate this week's album, explore leaderboard results, and join a community of dedicated listeners." />
-    <meta name="twitter:image" content="https://vinylvote.example/static/favicon_64x64.png" />
+    <meta name="twitter:image" content="%VITE_PUBLIC_SITE_URL%/static/favicon_64x64.png" />
     <link rel="icon" href="/static/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon_16x16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon_32x32.png" />
     <link rel="icon" type="image/png" sizes="64x64" href="/static/favicon_64x64.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/static/favicon_180x180.png" />
     <link rel="manifest" href="/static/manifest.json" />
-    <link rel="canonical" href="https://vinylvote.example/" />
+    <link rel="canonical" href="%VITE_PUBLIC_SITE_URL%/" />
     <title>Vinyl Vote V2</title>
     <script>
       (function () {
@@ -61,7 +61,7 @@
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "Vinyl Vote",
-        "url": "https://vinylvote.example/",
+        "url": "%VITE_PUBLIC_SITE_URL%/",
         "description": "Vinyl Vote is a weekly album voting community where listeners rate tracks, compare results, and discover standout records."
       }
     </script>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -45,6 +45,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location = /logout {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /legacy/ {
         proxy_pass http://web:5000;
         proxy_set_header Host $host;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -51,6 +51,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /share-card/ {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /legacy/ {
         proxy_pass http://web:5000;
         proxy_set_header Host $host;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,69 @@
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    location = /index.html {
+        try_files /index.html =404;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+    }
+
+    location /api/ {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /oauth/ {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /login {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /register {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /legacy/ {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /dev/ {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /static/ {
+        proxy_pass http://web:5000/static/;
+        proxy_set_header Host $host;
+        add_header Cache-Control "public, max-age=600" always;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.6.0",
+        "react-router-dom": "^6.30.1",
         "recharts": "^2.15.4"
       },
       "devDependencies": {
@@ -268,6 +269,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2167,6 +2177,38 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-smooth": {
       "version": "4.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.6.0",
+    "react-router-dom": "^6.30.1",
     "recharts": "^2.15.4"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,16 +27,16 @@ import TermsPage from "./pages/TermsPage";
 import { useRetroVotingFlow } from "./hooks/useRetroVotingFlow";
 import { useThemePreference } from "./hooks/useThemePreference";
 import { useVotingFlow } from "./hooks/useVotingFlow";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
-function parseHashRoute(hash) {
-  const raw = (hash || "").replace(/^#/, "").trim();
-  if (!raw || raw === "/") {
+function parsePathRoute(pathname) {
+  if (!pathname || pathname === "/") {
     return { page: "/home", albumId: null };
   }
 
-  const normalized = raw.startsWith("/") ? raw : `/${raw}`;
-  const [pathOnly] = normalized.split("?");
+  const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  const pathOnly = normalized;
 
   const retroVoteMatch = pathOnly.match(/^\/retro-vote\/(\d+)$/);
   if (retroVoteMatch) {
@@ -107,7 +107,8 @@ function App() {
   const showDevLogin = import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_LOGIN === "true";
   const showRetroPreviewOnHome = (import.meta.env.VITE_SHOW_RETRO_PREVIEW_ON_HOME || "false") === "true";
   const devLoginUsername = import.meta.env.VITE_DEV_LOGIN_USERNAME || "dev-user";
-  const [route, setRoute] = useState(parseHashRoute(window.location.hash));
+  const location = useLocation();
+  const route = parsePathRoute(location.pathname);
   const { theme, toggleTheme } = useThemePreference("dark");
   const {
     albumPayload,
@@ -146,17 +147,6 @@ function App() {
     "/extension",
   ].includes(route.page);
   const showGlobalSessionStatus = route.page !== "/home";
-
-  useEffect(() => {
-    function onHashChange() {
-      setRoute(parseHashRoute(window.location.hash));
-    }
-
-    window.addEventListener("hashchange", onHashChange);
-    return () => {
-      window.removeEventListener("hashchange", onHashChange);
-    };
-  }, []);
 
   useEffect(() => {
     if (route.page === "/retro-vote" && route.albumId) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -197,6 +197,10 @@ export function oauthLoginHref() {
   return buildUrl("/oauth/login");
 }
 
+export function logoutHref() {
+  return buildUrl("/logout");
+}
+
 let battleInFlightRequest = null;
 
 export function getBattle(options = {}) {

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import "./Footer.css";
 
 export default function Footer() {
@@ -7,9 +8,9 @@ export default function Footer() {
     <footer className="site-footer-v2" aria-label="Site footer">
       <p className="site-footer-v2-copy">
         &copy; {currentYear} Vinyl Vote - <span className="footer-gradient-text">byNolo</span> &middot;
-        <a href="/terms">Terms &amp; Conditions</a> |
-        <a href="/privacy">Privacy Policy</a> |
-        <a href="/extension">Browser Extension</a>
+        <Link to="/terms">Terms &amp; Conditions</Link> |
+        <Link to="/privacy">Privacy Policy</Link> |
+        <Link to="/extension">Browser Extension</Link>
       </p>
     </footer>
   );

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -7,9 +7,9 @@ export default function Footer() {
     <footer className="site-footer-v2" aria-label="Site footer">
       <p className="site-footer-v2-copy">
         &copy; {currentYear} Vinyl Vote - <span className="footer-gradient-text">byNolo</span> &middot;
-        <a href="#/terms">Terms &amp; Conditions</a> |
-        <a href="#/privacy">Privacy Policy</a> |
-        <a href="#/extension">Browser Extension</a>
+        <a href="/terms">Terms &amp; Conditions</a> |
+        <a href="/privacy">Privacy Policy</a> |
+        <a href="/extension">Browser Extension</a>
       </p>
     </footer>
   );

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -84,7 +84,7 @@ export default function Header({
   return (
     <header className="site-header">
       <div className="header-container">
-        <a className="brand-link" href="#/">
+        <a className="brand-link" href="/home">
           <img
             src={legacyPageHref("/static/favicon_64x64.png")}
             alt="Vinyl Vote logo"
@@ -109,13 +109,13 @@ export default function Header({
 
         <nav id="v2-nav" className={`nav-links ${menuOpen ? "open" : ""}`}>
           <div className="nav-group primary-group">
-            <a href="#/" className={route === "/home" ? "active" : ""} onClick={closeMobileOverlays}>Home</a>
+            <a href="/home" className={route === "/home" ? "active" : ""} onClick={closeMobileOverlays}>Home</a>
 
             {sessionState === "authenticated" && (
               <>
-                <a href="#/vote" className={route === "/vote" ? "active" : ""} onClick={closeMobileOverlays}>Vote</a>
-                <a href="#/battle" className={route === "/battle" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off</a>
-                <a href="#/retro-hub" className={route === "/retro-hub" || route === "/retro-vote" ? "active" : ""} onClick={closeMobileOverlays}>Retro Hub</a>
+                <a href="/vote" className={route === "/vote" ? "active" : ""} onClick={closeMobileOverlays}>Vote</a>
+                <a href="/battle" className={route === "/battle" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off</a>
+                <a href="/retro-hub" className={route === "/retro-hub" || route === "/retro-vote" ? "active" : ""} onClick={closeMobileOverlays}>Retro Hub</a>
               </>
             )}
 
@@ -130,12 +130,12 @@ export default function Header({
                 Data <ChevronDownIcon className="icon-right" />
               </button>
               <div className="dropdown-content">
-                <a href="#/results" className={route === "/results" ? "active" : ""} onClick={closeMobileOverlays}>Weekly Results</a>
+                <a href="/results" className={route === "/results" ? "active" : ""} onClick={closeMobileOverlays}>Weekly Results</a>
                 <div className="dropdown-divider" />
-                <a href="#/top-albums" className={route === "/top-albums" ? "active" : ""} onClick={closeMobileOverlays}>Top Albums</a>
-                <a href="#/top-artists" className={route === "/top-artists" ? "active" : ""} onClick={closeMobileOverlays}>Top Artists</a>
-                <a href="#/top-songs" className={route === "/top-songs" ? "active" : ""} onClick={closeMobileOverlays}>Top Songs</a>
-                <a href="#/faceoff-leaderboard" className={route === "/faceoff-leaderboard" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off Leaderboard</a>
+                <a href="/top-albums" className={route === "/top-albums" ? "active" : ""} onClick={closeMobileOverlays}>Top Albums</a>
+                <a href="/top-artists" className={route === "/top-artists" ? "active" : ""} onClick={closeMobileOverlays}>Top Artists</a>
+                <a href="/top-songs" className={route === "/top-songs" ? "active" : ""} onClick={closeMobileOverlays}>Top Songs</a>
+                <a href="/faceoff-leaderboard" className={route === "/faceoff-leaderboard" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off Leaderboard</a>
               </div>
             </div>
           </div>
@@ -143,7 +143,7 @@ export default function Header({
           <div className="nav-group user-group">
             {sessionState === "authenticated" ? (
               <>
-                <a href="#/song-requests" className={`nav-btn request-btn ${route === "/song-requests" ? "active" : ""}`} onClick={closeMobileOverlays}>
+                <a href="/song-requests" className={`nav-btn request-btn ${route === "/song-requests" ? "active" : ""}`} onClick={closeMobileOverlays}>
                   <PlusCircleIcon className="icon-left" />
                   Request
                 </a>
@@ -165,7 +165,7 @@ export default function Header({
                     <div className="dropdown-header">
                       Signed in as <strong>{sessionInfo?.username || "user"}</strong>
                     </div>
-                    <a href="#/profile" className={route === "/profile" ? "active" : ""} onClick={closeMobileOverlays}>Profile</a>
+                    <a href="/profile" className={route === "/profile" ? "active" : ""} onClick={closeMobileOverlays}>Profile</a>
                     <div className="dropdown-divider" />
                     <a href={legacyPageHref("/logout")} onClick={closeMobileOverlays}>Sign Out</a>
                   </div>
@@ -174,7 +174,7 @@ export default function Header({
             ) : (
               <>
                 <a className="nav-btn login-btn" href={loginHref} onClick={closeMobileOverlays}>Login</a>
-                <a className="nav-btn" href={legacyLoginHref} onClick={closeMobileOverlays}>Legacy Login</a>
+                {/* <a className="nav-btn" href={legacyLoginHref} onClick={closeMobileOverlays}>Legacy Login</a> */}
               </>
             )}
 

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
-import { legacyPageHref } from "../../api";
+import { Link } from "react-router-dom";
+import { legacyPageHref, logoutHref } from "../../api";
 import "./Header.css";
 
 function isMobileWidth() {
@@ -84,7 +85,7 @@ export default function Header({
   return (
     <header className="site-header">
       <div className="header-container">
-        <a className="brand-link" href="/home">
+        <Link className="brand-link" to="/home" onClick={closeMobileOverlays}>
           <img
             src={legacyPageHref("/static/favicon_64x64.png")}
             alt="Vinyl Vote logo"
@@ -95,7 +96,7 @@ export default function Header({
           <span>
             Vinyl Vote <span className="brand-footnote"><span className="gradient-text">byNolo</span></span>
           </span>
-        </a>
+        </Link>
 
         <button
           className="mobile-menu-toggle"
@@ -109,13 +110,13 @@ export default function Header({
 
         <nav id="v2-nav" className={`nav-links ${menuOpen ? "open" : ""}`}>
           <div className="nav-group primary-group">
-            <a href="/home" className={route === "/home" ? "active" : ""} onClick={closeMobileOverlays}>Home</a>
+            <Link to="/home" className={route === "/home" ? "active" : ""} onClick={closeMobileOverlays}>Home</Link>
 
             {sessionState === "authenticated" && (
               <>
-                <a href="/vote" className={route === "/vote" ? "active" : ""} onClick={closeMobileOverlays}>Vote</a>
-                <a href="/battle" className={route === "/battle" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off</a>
-                <a href="/retro-hub" className={route === "/retro-hub" || route === "/retro-vote" ? "active" : ""} onClick={closeMobileOverlays}>Retro Hub</a>
+                <Link to="/vote" className={route === "/vote" ? "active" : ""} onClick={closeMobileOverlays}>Vote</Link>
+                <Link to="/battle" className={route === "/battle" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off</Link>
+                <Link to="/retro-hub" className={route === "/retro-hub" || route === "/retro-vote" ? "active" : ""} onClick={closeMobileOverlays}>Retro Hub</Link>
               </>
             )}
 
@@ -130,12 +131,12 @@ export default function Header({
                 Data <ChevronDownIcon className="icon-right" />
               </button>
               <div className="dropdown-content">
-                <a href="/results" className={route === "/results" ? "active" : ""} onClick={closeMobileOverlays}>Weekly Results</a>
+                <Link to="/results" className={route === "/results" ? "active" : ""} onClick={closeMobileOverlays}>Weekly Results</Link>
                 <div className="dropdown-divider" />
-                <a href="/top-albums" className={route === "/top-albums" ? "active" : ""} onClick={closeMobileOverlays}>Top Albums</a>
-                <a href="/top-artists" className={route === "/top-artists" ? "active" : ""} onClick={closeMobileOverlays}>Top Artists</a>
-                <a href="/top-songs" className={route === "/top-songs" ? "active" : ""} onClick={closeMobileOverlays}>Top Songs</a>
-                <a href="/faceoff-leaderboard" className={route === "/faceoff-leaderboard" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off Leaderboard</a>
+                <Link to="/top-albums" className={route === "/top-albums" ? "active" : ""} onClick={closeMobileOverlays}>Top Albums</Link>
+                <Link to="/top-artists" className={route === "/top-artists" ? "active" : ""} onClick={closeMobileOverlays}>Top Artists</Link>
+                <Link to="/top-songs" className={route === "/top-songs" ? "active" : ""} onClick={closeMobileOverlays}>Top Songs</Link>
+                <Link to="/faceoff-leaderboard" className={route === "/faceoff-leaderboard" ? "active" : ""} onClick={closeMobileOverlays}>Face-Off Leaderboard</Link>
               </div>
             </div>
           </div>
@@ -143,10 +144,10 @@ export default function Header({
           <div className="nav-group user-group">
             {sessionState === "authenticated" ? (
               <>
-                <a href="/song-requests" className={`nav-btn request-btn ${route === "/song-requests" ? "active" : ""}`} onClick={closeMobileOverlays}>
+                <Link to="/song-requests" className={`nav-btn request-btn ${route === "/song-requests" ? "active" : ""}`} onClick={closeMobileOverlays}>
                   <PlusCircleIcon className="icon-left" />
                   Request
-                </a>
+                </Link>
 
                 <div className={`dropdown user-dropdown ${userDropdownOpen ? "open" : ""}`}>
                   <button
@@ -165,9 +166,9 @@ export default function Header({
                     <div className="dropdown-header">
                       Signed in as <strong>{sessionInfo?.username || "user"}</strong>
                     </div>
-                    <a href="/profile" className={route === "/profile" ? "active" : ""} onClick={closeMobileOverlays}>Profile</a>
+                    <Link to="/profile" className={route === "/profile" ? "active" : ""} onClick={closeMobileOverlays}>Profile</Link>
                     <div className="dropdown-divider" />
-                    <a href={legacyPageHref("/logout")} onClick={closeMobileOverlays}>Sign Out</a>
+                    <a href={logoutHref()} onClick={closeMobileOverlays}>Sign Out</a>
                   </div>
                 </div>
               </>

--- a/frontend/src/components/profile/ProfileAlbumHistory.jsx
+++ b/frontend/src/components/profile/ProfileAlbumHistory.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { legacyPageHref } from "../../api";
 
 function formatScore(value) {
@@ -17,6 +18,7 @@ export default function ProfileAlbumHistory({ albumVotes, search, onSearchChange
     const voteCardHref = item.vote_card_href?.startsWith("http")
       ? item.vote_card_href
       : legacyPageHref(item.vote_card_href || "");
+    const resultsPath = item.results_href || `/results/${item.album.id}`;
 
     return (
       <article key={item.album.id} className="profile-history-card">
@@ -34,7 +36,7 @@ export default function ProfileAlbumHistory({ albumVotes, search, onSearchChange
           )}
           <div>
             <h3>
-              <a href={item.results_href}>{item.album.title}</a>
+              <Link to={resultsPath}>{item.album.title}</Link>
             </h3>
             <p>{item.album.artist}</p>
             <p>Your album score: <strong>{formatScore(item.album_score)}</strong></p>
@@ -64,7 +66,7 @@ export default function ProfileAlbumHistory({ albumVotes, search, onSearchChange
         </div>
 
         <div className="profile-history-actions">
-          <a className="btn btn-secondary" href={item.results_href}>View Results</a>
+          <Link className="btn btn-secondary" to={resultsPath}>View Results</Link>
           <a className="btn btn-ghost" href={voteCardHref} target="_blank" rel="noopener noreferrer">Download Vote Card</a>
         </div>
       </article>

--- a/frontend/src/hooks/useLeaderboardCollection.js
+++ b/frontend/src/hooks/useLeaderboardCollection.js
@@ -1,16 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 export function parseInitialQuery(routePath, defaults) {
-  const hash = (window.location.hash || "").replace(/^#/, "").trim();
-  if (!hash) {
+  const pathPart = window.location.pathname || "";
+  if (!pathPart) {
     return { ...defaults };
   }
 
-  const [pathPart, queryPart = ""] = hash.split("?");
   if (pathPart !== routePath) {
     return { ...defaults };
   }
 
+  const queryPart = window.location.search?.replace(/^\?/, "") || "";
   const params = new URLSearchParams(queryPart);
   const next = { ...defaults };
 
@@ -31,7 +31,7 @@ export function parseInitialQuery(routePath, defaults) {
   return next;
 }
 
-function syncHash(routePath, query, defaults) {
+function syncQuery(routePath, query, defaults) {
   const params = new URLSearchParams();
   Object.entries(query).forEach(([key, value]) => {
     if (value === undefined || value === null || value === "") {
@@ -44,8 +44,7 @@ function syncHash(routePath, query, defaults) {
   });
 
   const suffix = params.toString();
-  const nextHash = suffix ? `#${routePath}?${suffix}` : `#${routePath}`;
-  const nextUrl = `${window.location.pathname}${window.location.search}${nextHash}`;
+  const nextUrl = suffix ? `${routePath}?${suffix}` : routePath;
   window.history.replaceState(null, "", nextUrl);
 }
 
@@ -76,7 +75,7 @@ export function useLeaderboardCollection({ routePath, fetcher, defaults }) {
   }, [fetcher, requestPayload]);
 
   useEffect(() => {
-    syncHash(routePath, query, defaults);
+    syncQuery(routePath, query, defaults);
   }, [defaults, query, routePath]);
 
   useEffect(() => {

--- a/frontend/src/hooks/useLeaderboardCollection.test.js
+++ b/frontend/src/hooks/useLeaderboardCollection.test.js
@@ -11,11 +11,11 @@ describe("parseInitialQuery", () => {
   };
 
   afterEach(() => {
-    window.location.hash = "";
+    window.history.replaceState(null, "", "/");
   });
 
   it("parses numeric parameters as numbers", () => {
-    window.location.hash = "#/top-songs?page=2&per_page=10&min_ratings=5";
+    window.history.replaceState(null, "", "/top-songs?page=2&per_page=10&min_ratings=5");
 
     const parsed = parseInitialQuery("/top-songs", defaults);
 
@@ -25,7 +25,7 @@ describe("parseInitialQuery", () => {
   });
 
   it("parses string parameters", () => {
-    window.location.hash = "#/top-songs?q=metallica&sort_by=title&sort_dir=asc";
+    window.history.replaceState(null, "", "/top-songs?q=metallica&sort_by=title&sort_dir=asc");
 
     const parsed = parseInitialQuery("/top-songs", defaults);
 
@@ -35,7 +35,7 @@ describe("parseInitialQuery", () => {
   });
 
   it("uses defaults for missing parameters", () => {
-    window.location.hash = "#/top-songs?q=power";
+    window.history.replaceState(null, "", "/top-songs?q=power");
 
     const parsed = parseInitialQuery("/top-songs", defaults);
 
@@ -46,7 +46,7 @@ describe("parseInitialQuery", () => {
   });
 
   it("falls back to default for invalid numeric parameters", () => {
-    window.location.hash = "#/top-songs?page=not-a-number&per_page=oops&min_ratings=NaN";
+    window.history.replaceState(null, "", "/top-songs?page=not-a-number&per_page=oops&min_ratings=NaN");
 
     const parsed = parseInitialQuery("/top-songs", defaults);
 
@@ -55,8 +55,8 @@ describe("parseInitialQuery", () => {
     expect(parsed.min_ratings).toBe(defaults.min_ratings);
   });
 
-  it("returns defaults when hash path does not match route", () => {
-    window.location.hash = "#/top-artists?page=3&q=abc";
+  it("returns defaults when path does not match route", () => {
+    window.history.replaceState(null, "", "/top-artists?page=3&q=abc");
 
     const parsed = parseInitialQuery("/top-songs", defaults);
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles/index.css";
 
 createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/BattlePage.jsx
+++ b/frontend/src/pages/BattlePage.jsx
@@ -135,7 +135,7 @@ export default function BattlePage({ sessionState, theme }) {
 
         <div className="skip-container">
           <button className="btn btn-secondary" type="button" onClick={() => loadPair({ force: true })}>Skip this match</button>
-          <a className="muted-link" href="#/faceoff-leaderboard">View Face-Off Leaderboard</a>
+          <a className="muted-link" href="/faceoff-leaderboard">View Face-Off Leaderboard</a>
         </div>
 
         {result ? (

--- a/frontend/src/pages/BattlePage.jsx
+++ b/frontend/src/pages/BattlePage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { getBattle, legacyPageHref, submitBattleVote } from "../api";
 import StatusCard from "../components/common/StatusCard";
 import BattleCard from "../components/battle/BattleCard";
@@ -135,7 +136,7 @@ export default function BattlePage({ sessionState, theme }) {
 
         <div className="skip-container">
           <button className="btn btn-secondary" type="button" onClick={() => loadPair({ force: true })}>Skip this match</button>
-          <a className="muted-link" href="/faceoff-leaderboard">View Face-Off Leaderboard</a>
+          <Link className="muted-link" to="/faceoff-leaderboard">View Face-Off Leaderboard</Link>
         </div>
 
         {result ? (

--- a/frontend/src/pages/FaceoffLeaderboardPage.jsx
+++ b/frontend/src/pages/FaceoffLeaderboardPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { getLeaderboardBattle, legacyPageHref } from "../api";
+import { Link } from "react-router-dom";
+import { getLeaderboardBattle } from "../api";
 import LeaderboardPagination from "../components/common/LeaderboardPagination";
 import LeaderboardTableSkeleton from "../components/common/LeaderboardTableSkeleton";
 import LeaderboardTable from "../components/common/LeaderboardTable";
@@ -123,9 +124,9 @@ export default function FaceoffLeaderboardPage() {
         sortKey: "artist",
         width: "220px",
         render: (row) => (
-          <a className="bare-link" href={`/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
+          <Link className="bare-link" to={`/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
             {row.album?.artist || "Unknown"}
-          </a>
+          </Link>
         ),
       },
       {
@@ -157,7 +158,7 @@ export default function FaceoffLeaderboardPage() {
           <h1>Face-Off Leaderboard</h1>
           <p className="subtitle">Elo-based fan favorites ranked by battle outcomes.</p>
         </div>
-        <a className="btn btn-primary" href="/battle">Play Face-Off</a>
+        <Link className="btn btn-primary" to="/battle">Play Face-Off</Link>
       </section>
 
       <LeaderboardToolbar

--- a/frontend/src/pages/FaceoffLeaderboardPage.jsx
+++ b/frontend/src/pages/FaceoffLeaderboardPage.jsx
@@ -123,7 +123,7 @@ export default function FaceoffLeaderboardPage() {
         sortKey: "artist",
         width: "220px",
         render: (row) => (
-          <a className="bare-link" href={`#/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
+          <a className="bare-link" href={`/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
             {row.album?.artist || "Unknown"}
           </a>
         ),
@@ -157,7 +157,7 @@ export default function FaceoffLeaderboardPage() {
           <h1>Face-Off Leaderboard</h1>
           <p className="subtitle">Elo-based fan favorites ranked by battle outcomes.</p>
         </div>
-        <a className="btn btn-primary" href="#/battle">Play Face-Off</a>
+        <a className="btn btn-primary" href="/battle">Play Face-Off</a>
       </section>
 
       <LeaderboardToolbar

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { getHomeData, getHomeSeo } from "../api";
 import StatusCard from "../components/common/StatusCard";
 import StreamingLinks from "../components/common/StreamingLinks";
@@ -327,7 +328,7 @@ function HomePageSkeleton() {
 
 function AlbumTile({ album, metricLabel }) {
   const [tilePalette, setTilePalette] = useState(defaultCardPalette);
-  const albumResultsHref = `/results/${album.id}`;
+  const albumResultsPath = `/results/${album.id}`;
 
   useEffect(() => {
     let cancelled = false;
@@ -369,9 +370,9 @@ function AlbumTile({ album, metricLabel }) {
   }, [album?.cover_url]);
 
   return (
-    <a
+    <Link
       className="home-tile home-tile-link"
-      href={albumResultsHref}
+      to={albumResultsPath}
       aria-label={`View results for ${album.title} by ${album.artist}`}
       style={{
         "--home-tile-primary": tilePalette.primary,
@@ -402,7 +403,7 @@ function AlbumTile({ album, metricLabel }) {
           <strong>Album Avg:</strong> {album.avg_album_score ?? "N/A"}
         </p>
       </div>
-    </a>
+    </Link>
   );
 }
 
@@ -680,14 +681,14 @@ export default function HomePage({ loginHref, legacyLoginHref }) {
 
             <div className="button-row home-cta-row">
               {homeData?.user?.is_authenticated ? (
-                <a className="btn btn-primary" href="/vote">Go Vote</a>
+                <Link className="btn btn-primary" to="/vote">Go Vote</Link>
               ) : (
                 <>
                   <a className="btn btn-primary" href={loginHref}>Log In to Vote</a>
                   {/* <a className="btn btn-secondary" href={legacyLoginHref}>Legacy Login</a> */}
                 </>
               )}
-              <a className="btn btn-secondary" href="/battle">Face-Off</a>
+              <Link className="btn btn-secondary" to="/battle">Face-Off</Link>
             </div>
           </div>
         </div>
@@ -756,11 +757,11 @@ export default function HomePage({ loginHref, legacyLoginHref }) {
 
         <div className="button-row home-join-actions">
           {homeData?.user?.is_authenticated ? (
-            <a className="btn btn-primary" href="/vote">Start This Week's Vote</a>
+            <Link className="btn btn-primary" to="/vote">Start This Week's Vote</Link>
           ) : (
             <a className="btn btn-primary" href={loginHref}>Create or Use Your Account</a>
           )}
-          <a className="btn btn-ghost" href="/results">See Past Results</a>
+          <Link className="btn btn-ghost" to="/results">See Past Results</Link>
         </div>
       </section>
 
@@ -776,7 +777,7 @@ export default function HomePage({ loginHref, legacyLoginHref }) {
 
         <div className="home-action-grid" role="group" aria-label="Quick action links">
           {homeActions.map((action) => (
-            <a key={action.href} className="home-action" href={action.href}>{action.label}</a>
+            <Link key={action.href} className="home-action" to={action.href}>{action.label}</Link>
           ))}
           {installPromptEvent ? (
             <button className="home-action home-action-button" type="button" onClick={handleInstallPrompt}>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -684,7 +684,7 @@ export default function HomePage({ loginHref, legacyLoginHref }) {
               ) : (
                 <>
                   <a className="btn btn-primary" href={loginHref}>Log In to Vote</a>
-                  <a className="btn btn-secondary" href={legacyLoginHref}>Legacy Login</a>
+                  {/* <a className="btn btn-secondary" href={legacyLoginHref}>Legacy Login</a> */}
                 </>
               )}
               <a className="btn btn-secondary" href="/battle">Face-Off</a>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -327,7 +327,7 @@ function HomePageSkeleton() {
 
 function AlbumTile({ album, metricLabel }) {
   const [tilePalette, setTilePalette] = useState(defaultCardPalette);
-  const albumResultsHref = `#/results/${album.id}`;
+  const albumResultsHref = `/results/${album.id}`;
 
   useEffect(() => {
     let cancelled = false;
@@ -542,17 +542,17 @@ export default function HomePage({ loginHref, legacyLoginHref }) {
 
   const homeActions = useMemo(() => {
     const actions = [
-      { href: "#/results", label: "Latest Results" },
-      { href: "#/battle", label: "Face-Off" },
-      { href: "#/top-albums", label: "Top Albums" },
-      { href: "#/top-artists", label: "Top Artists" },
-      { href: "#/top-songs", label: "Top Songs" },
+      { href: "/results", label: "Latest Results" },
+      { href: "/battle", label: "Face-Off" },
+      { href: "/top-albums", label: "Top Albums" },
+      { href: "/top-artists", label: "Top Artists" },
+      { href: "/top-songs", label: "Top Songs" },
     ];
 
     if (homeData?.user?.is_authenticated) {
-      actions.unshift({ href: "#/vote", label: "Resume Voting" });
-      actions.push({ href: "#/retro-hub", label: "Retro Hub" });
-      actions.push({ href: "#/song-requests", label: "Request an Album" });
+      actions.unshift({ href: "/vote", label: "Resume Voting" });
+      actions.push({ href: "/retro-hub", label: "Retro Hub" });
+      actions.push({ href: "/song-requests", label: "Request an Album" });
     }
 
     return actions;
@@ -680,14 +680,14 @@ export default function HomePage({ loginHref, legacyLoginHref }) {
 
             <div className="button-row home-cta-row">
               {homeData?.user?.is_authenticated ? (
-                <a className="btn btn-primary" href="#/vote">Go Vote</a>
+                <a className="btn btn-primary" href="/vote">Go Vote</a>
               ) : (
                 <>
                   <a className="btn btn-primary" href={loginHref}>Log In to Vote</a>
                   <a className="btn btn-secondary" href={legacyLoginHref}>Legacy Login</a>
                 </>
               )}
-              <a className="btn btn-secondary" href="#/battle">Face-Off</a>
+              <a className="btn btn-secondary" href="/battle">Face-Off</a>
             </div>
           </div>
         </div>
@@ -756,11 +756,11 @@ export default function HomePage({ loginHref, legacyLoginHref }) {
 
         <div className="button-row home-join-actions">
           {homeData?.user?.is_authenticated ? (
-            <a className="btn btn-primary" href="#/vote">Start This Week's Vote</a>
+            <a className="btn btn-primary" href="/vote">Start This Week's Vote</a>
           ) : (
             <a className="btn btn-primary" href={loginHref}>Create or Use Your Account</a>
           )}
-          <a className="btn btn-ghost" href="#/results">See Past Results</a>
+          <a className="btn btn-ghost" href="/results">See Past Results</a>
         </div>
       </section>
 

--- a/frontend/src/pages/RetroHubPage.jsx
+++ b/frontend/src/pages/RetroHubPage.jsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import "./RetroHubPage.css";
 
 export default function RetroHubPage({ retro }) {
+  const navigate = useNavigate();
   const [query, setQuery] = useState("");
 
   const filteredAlbums = useMemo(() => {
@@ -15,7 +17,7 @@ export default function RetroHubPage({ retro }) {
   }, [query, retro.albums]);
 
   function openRetroVote(albumId) {
-    window.location.hash = `#/retro-vote/${albumId}`;
+    navigate(`/retro-vote/${albumId}`);
   }
 
   return (

--- a/frontend/src/pages/TopAlbumsPage.jsx
+++ b/frontend/src/pages/TopAlbumsPage.jsx
@@ -86,7 +86,7 @@ export default function TopAlbumsPage() {
         sortKey: "title",
         render: (row) => (
           <div className="album-cell">
-            <a className="bare-link" href={`#/results/${row.id}`}>{row.title}</a>
+            <a className="bare-link" href={`/results/${row.id}`}>{row.title}</a>
             <p className="muted-copy">{row.artist}</p>
           </div>
         ),

--- a/frontend/src/pages/TopAlbumsPage.jsx
+++ b/frontend/src/pages/TopAlbumsPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { getLeaderboardAlbums } from "../api";
 import LeaderboardPagination from "../components/common/LeaderboardPagination";
 import LeaderboardTableSkeleton from "../components/common/LeaderboardTableSkeleton";
@@ -86,7 +87,7 @@ export default function TopAlbumsPage() {
         sortKey: "title",
         render: (row) => (
           <div className="album-cell">
-            <a className="bare-link" href={`/results/${row.id}`}>{row.title}</a>
+            <Link className="bare-link" to={`/results/${row.id}`}>{row.title}</Link>
             <p className="muted-copy">{row.artist}</p>
           </div>
         ),

--- a/frontend/src/pages/TopSongsPage.jsx
+++ b/frontend/src/pages/TopSongsPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { getLeaderboardSongs } from "../api";
 import LeaderboardPagination from "../components/common/LeaderboardPagination";
 import LeaderboardTableSkeleton from "../components/common/LeaderboardTableSkeleton";
@@ -104,9 +105,9 @@ export default function TopSongsPage() {
         sortable: true,
         sortKey: "artist",
         render: (row) => (
-          <a className="bare-link" href={`/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
+          <Link className="bare-link" to={`/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
             {row.album?.artist || "Unknown"}
-          </a>
+          </Link>
         ),
       },
       {
@@ -115,7 +116,7 @@ export default function TopSongsPage() {
         sortable: true,
         sortKey: "album",
         render: (row) => (
-          row.album?.id ? <a className="bare-link" href={`/results/${row.album.id}`}>{row.album.title}</a> : "-"
+          row.album?.id ? <Link className="bare-link" to={`/results/${row.album.id}`}>{row.album.title}</Link> : "-"
         ),
       },
       {

--- a/frontend/src/pages/TopSongsPage.jsx
+++ b/frontend/src/pages/TopSongsPage.jsx
@@ -104,7 +104,7 @@ export default function TopSongsPage() {
         sortable: true,
         sortKey: "artist",
         render: (row) => (
-          <a className="bare-link" href={`#/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
+          <a className="bare-link" href={`/top-artists?q=${encodeURIComponent(row.album?.artist || "")}`}>
             {row.album?.artist || "Unknown"}
           </a>
         ),
@@ -115,7 +115,7 @@ export default function TopSongsPage() {
         sortable: true,
         sortKey: "album",
         render: (row) => (
-          row.album?.id ? <a className="bare-link" href={`#/results/${row.album.id}`}>{row.album.title}</a> : "-"
+          row.album?.id ? <a className="bare-link" href={`/results/${row.album.id}`}>{row.album.title}</a> : "-"
         ),
       },
       {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -26,6 +26,10 @@ export default defineConfig({
         target: "http://127.0.0.1:5000",
         changeOrigin: true,
       },
+      "/logout": {
+        target: "http://127.0.0.1:5000",
+        changeOrigin: true,
+      },
       "/register": {
         target: "http://127.0.0.1:5000",
         changeOrigin: true,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  base: process.env.VITE_BASE || "/",
   test: {
     environment: "jsdom",
     globals: true,

--- a/run.py
+++ b/run.py
@@ -1,6 +1,8 @@
 from app import create_app
+import os
 
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    debug_enabled = os.getenv("FLASK_DEBUG", "false").lower() in ("1", "true", "yes")
+    app.run(debug=debug_enabled)


### PR DESCRIPTION
## Summary

- Migrated V2 navigation and auth-related flows to work correctly with BrowserRouter in production.
- Fixed logout behavior end-to-end:
  - Header sign-out now targets backend logout reliably.
  - Backend logout hard-clears session/auth state.
  - Production Nginx now proxies `/logout` to Flask.
- Fixed profile links:
  - Results links now use path routing (`/results/<id>`) instead of hash routing.
  - Added production proxy for `/share-card/` so “Download Vote Card” reaches backend.
- Reduced header auth flicker while navigating by switching internal header nav to SPA client-side links.
- Includes branch-level deployment/routing updates (prod Docker/Nginx/frontend integration) and related frontend/backend/docs updates.

## Why

- After moving from hash routing to BrowserRouter, several routes were falling through to SPA fallback instead of backend handlers.
- This caused key regressions:
  - Logout appeared to work briefly but session remained active.
  - Vote card download route did not resolve.
  - Header briefly showed logged-out state during page transitions.
- These changes ensure backend routes are explicitly proxied and internal app navigation stays client-side.

## Linked Issue

N/A

## Type Of Change

- [x] feat
- [x] fix
- [ ] chore
- [x] docs
- [ ] test

## Scope

- [x] Backend (app)
- [x] Frontend V2 (frontend)
- [ ] Legacy templates (templates)
- [x] Docs / contributor workflow

## Testing

List what you ran and the result.

```bash
make lint
make test
cd frontend && npm run build
```

Results:
- `make lint`: pass
- `make test`: pass (32 passed)
- `cd frontend && npm run build`: pass

## Migration / Compatibility Notes

- [x] API changes are backward-compatible, or rationale is documented.
- [x] Legacy behavior impact considered for V2 migration.
- [x] Docs updated where needed.